### PR TITLE
Add fiber to per-entry stats line on diary list

### DIFF
--- a/src/DiaryList.tsx
+++ b/src/DiaryList.tsx
@@ -207,7 +207,9 @@ const DiaryList: Component = () => {
                       <li class="mb-4">
                         <p class="font-semibold">
                           {entry().calories} kcal,{" "}
-                          {entryTotalMacro("protein_grams", entry())}g protein
+                          {entryTotalMacro("protein_grams", entry())}g protein,{" "}
+                          {entryTotalMacro("dietary_fiber_grams", entry())}g
+                          fiber
                         </p>
                         <p>
                           <a

--- a/src/acceptance.test.tsx
+++ b/src/acceptance.test.tsx
@@ -90,6 +90,24 @@ describe("Browser Acceptance Tests", () => {
     expect(kcalElements).toHaveLength(2);
   });
 
+  it("should display fiber on each diary entry stats line", async () => {
+    render(() => (
+      <Router root={App}>
+        <Route path="/" component={DiaryList} />
+      </Router>
+    ));
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText(/Banana/i)).not.toBeNull();
+      },
+      { timeout: 5000 },
+    );
+
+    // Banana: 1 serving * 3.1g fiber
+    expect(screen.getByText(/3\.1g fiber/i)).toBeTruthy();
+  });
+
   it("should complete Add Item flow - create new item and log it", async () => {
     const user = userEvent.setup();
 

--- a/src/test-setup-browser.ts
+++ b/src/test-setup-browser.ts
@@ -24,6 +24,7 @@ const mockNutritionItems = [
     total_fat_grams: 0.4,
     added_sugars_grams: 0,
     protein_grams: 1.3,
+    dietary_fiber_grams: 3.1,
   },
   {
     id: 2,
@@ -32,6 +33,7 @@ const mockNutritionItems = [
     total_fat_grams: 0.3,
     added_sugars_grams: 0,
     protein_grams: 0.5,
+    dietary_fiber_grams: 4.4,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Adds fiber to the per-entry stats line, which now reads: `X kcal, Yg protein, Zg fiber`

## Test plan
- [ ] Open the diary list and verify each entry shows kcal, protein, and fiber
- [ ] Confirm fiber values are correct based on the entry's servings

https://claude.ai/code/session_01K2KuUxkaFgvB33ktwcDgSC