### PR TITLE
Move KCAL stat back to left column below date badge

### DIFF
--- a/src/DiaryList.tsx
+++ b/src/DiaryList.tsx
@@ -168,22 +168,22 @@ const DiaryList: Component = () => {
               <li class="grid grid-cols-6 -ml-4 mb-6">
                 <div>
                   <DateBadge class="col-span-1" date={parseISO(dateStr())} />
+                  <CircleProgress
+                    value={Math.ceil(
+                      entries().reduce(
+                        (acc: number, entry: DiaryEntry) =>
+                          acc + entry.calories,
+                        0,
+                      ),
+                    )}
+                    target={targets().calories}
+                    max={targets().calories_max}
+                    label="KCAL"
+                  />
                 </div>
                 <ul class="col-span-5 mb-6">
                   <li class="mb-4">
                     <div class="flex flex-row justify-around">
-                      <CircleProgress
-                        value={Math.ceil(
-                          entries().reduce(
-                            (acc: number, entry: DiaryEntry) =>
-                              acc + entry.calories,
-                            0,
-                          ),
-                        )}
-                        target={targets().calories}
-                        max={targets().calories_max}
-                        label="KCAL"
-                      />
                       <CircleProgress
                         value={totalMacro("added_sugars_grams", entries())}
                         target={targets().added_sugars_grams}


### PR DESCRIPTION
Reverts the layout change from adding progress circles — the KCAL CircleProgress
is now positioned in the left column beneath the DateBadge instead of inline
with the other nutrition circles on the right.

https://claude.ai/code/session_01R1pTwkhmzmSHHBsUtCs2H3