### PR TITLE
Add date range UI to entry export as a dedicated page

### DIFF
--- a/src/Api.ts
+++ b/src/Api.ts
@@ -644,7 +644,7 @@ export async function insertDiaryEntries(
   });
 }
 
-const exportEntriesQuery = `
+const nutritionItemFragment = `
 fragment nutritionItem on food_diary_nutrition_item {
   description
   calories
@@ -660,10 +660,9 @@ fragment nutritionItem on food_diary_nutrition_item {
   total_sugars_grams
   added_sugars_grams
   protein_grams
-}
+}`;
 
-query ExportEntries {
-  food_diary_diary_entry {
+const entryFields = `
     servings
     consumed_at
     nutrition_item {
@@ -672,16 +671,42 @@ query ExportEntries {
     recipe {
       name
       recipe_items {
-				servings
+        servings
         nutrition_item {
           ...nutritionItem
         }
       }
-    }
+    }`;
+
+const exportEntriesQuery = `
+${nutritionItemFragment}
+
+query ExportEntries {
+  food_diary_diary_entry {
+    ${entryFields}
   }
 }`;
 
-export async function fetchExportEntries(accessToken: string) {
+const exportEntriesWithDateRangeQuery = `
+${nutritionItemFragment}
+
+query ExportEntriesWithDateRange($startDate: timestamptz!, $endDate: timestamptz!) {
+  food_diary_diary_entry(where: { consumed_at: { _gte: $startDate, _lte: $endDate } }) {
+    ${entryFields}
+  }
+}`;
+
+export async function fetchExportEntries(
+  accessToken: string,
+  startDate?: string,
+  endDate?: string,
+) {
+  if (startDate && endDate) {
+    return await fetchQuery(accessToken, exportEntriesWithDateRangeQuery, {
+      startDate,
+      endDate,
+    });
+  }
   return await fetchQuery(accessToken, exportEntriesQuery);
 }
 

--- a/src/CircleProgress.tsx
+++ b/src/CircleProgress.tsx
@@ -60,7 +60,9 @@ const CircleProgress: Component<{
           {props.unit}
         </text>
       </svg>
-      <p class="text-sm uppercase text-slate-700 mt-0.5 text-center">{props.label}</p>
+      <p class="text-sm uppercase text-slate-700 mt-0.5 text-center">
+        {props.label}
+      </p>
     </div>
   );
 };

--- a/src/ExportDiaryEntries.test.tsx
+++ b/src/ExportDiaryEntries.test.tsx
@@ -118,13 +118,14 @@ describe("ExportDiaryEntries", () => {
 
   it("should export with date range variables when date inputs are set", async () => {
     const user = userEvent.setup();
-    let capturedRequestBody: {
+    let capturedRequestBody!: {
       variables: { startDate: string; endDate: string };
     };
 
     server.use(
       http.post("/api/v1/graphql", async ({ request }) => {
-        capturedRequestBody = await request.json();
+        capturedRequestBody =
+          (await request.json()) as typeof capturedRequestBody;
         return HttpResponse.json(exportResponse);
       }),
     );
@@ -157,11 +158,12 @@ describe("ExportDiaryEntries", () => {
 
   it("should export all entries with no date variables when 'All dates' is checked", async () => {
     const user = userEvent.setup();
-    let capturedRequestBody: { variables: Record<string, never> };
+    let capturedRequestBody!: { variables: Record<string, never> };
 
     server.use(
       http.post("/api/v1/graphql", async ({ request }) => {
-        capturedRequestBody = await request.json();
+        capturedRequestBody =
+          (await request.json()) as typeof capturedRequestBody;
         return HttpResponse.json(exportResponse);
       }),
     );

--- a/src/ExportDiaryEntries.test.tsx
+++ b/src/ExportDiaryEntries.test.tsx
@@ -118,7 +118,9 @@ describe("ExportDiaryEntries", () => {
 
   it("should export with date range variables when date inputs are set", async () => {
     const user = userEvent.setup();
-    let capturedRequestBody: any;
+    let capturedRequestBody: {
+      variables: { startDate: string; endDate: string };
+    };
 
     server.use(
       http.post("/api/v1/graphql", async ({ request }) => {
@@ -155,7 +157,7 @@ describe("ExportDiaryEntries", () => {
 
   it("should export all entries with no date variables when 'All dates' is checked", async () => {
     const user = userEvent.setup();
-    let capturedRequestBody: any;
+    let capturedRequestBody: { variables: Record<string, never> };
 
     server.use(
       http.post("/api/v1/graphql", async ({ request }) => {

--- a/src/ExportDiaryEntries.test.tsx
+++ b/src/ExportDiaryEntries.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "./test-setup";
+import ExportDiaryEntries from "./ExportDiaryEntries";
+
+vi.mock("./Auth0", () => ({
+  useAuth: () => [
+    {
+      accessToken: () => "test-token",
+    },
+  ],
+}));
+
+const exportResponse = {
+  data: {
+    food_diary_diary_entry: [
+      {
+        consumed_at: "2024-01-01T10:00:00Z",
+        servings: 1,
+        nutrition_item: {
+          description: "Apple",
+          calories: 95,
+          total_fat_grams: 0.3,
+          saturated_fat_grams: 0.1,
+          trans_fat_grams: 0,
+          polyunsaturated_fat_grams: 0.1,
+          monounsaturated_fat_grams: 0.1,
+          cholesterol_mg: 0,
+          sodium_mg: 2,
+          total_carbohydrate_grams: 25,
+          dietary_fiber_grams: 4,
+          total_sugars_grams: 19,
+          added_sugars_grams: 0,
+          protein_grams: 0.5,
+        },
+      },
+    ],
+  },
+};
+
+function mockDownload() {
+  const mockCreateObjectURL = vi.fn(() => "blob:mock-url");
+  const mockRevokeObjectURL = vi.fn();
+  global.URL.createObjectURL = mockCreateObjectURL;
+  global.URL.revokeObjectURL = mockRevokeObjectURL;
+
+  const mockAnchor = document.createElement("a");
+  const mockClick = vi.fn();
+  mockAnchor.click = mockClick;
+  const originalCreateElement = document.createElement.bind(document);
+  document.createElement = vi.fn((tag: string) => {
+    if (tag === "a") return mockAnchor;
+    return originalCreateElement(tag);
+  }) as any;
+
+  return {
+    mockCreateObjectURL,
+    mockRevokeObjectURL,
+    mockClick,
+    restore: () => {
+      document.createElement = originalCreateElement;
+    },
+  };
+}
+
+describe("ExportDiaryEntries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should show date range inputs defaulting to last 2 weeks", () => {
+    render(() => <ExportDiaryEntries />);
+
+    const fromInput = screen.getByLabelText("From") as HTMLInputElement;
+    const toInput = screen.getByLabelText("To") as HTMLInputElement;
+
+    expect(fromInput).toBeTruthy();
+    expect(toInput).toBeTruthy();
+
+    // Both inputs should be enabled by default
+    expect(fromInput.disabled).toBe(false);
+    expect(toInput.disabled).toBe(false);
+
+    // End date should be today
+    const today = new Date();
+    const yyyy = today.getFullYear();
+    const mm = String(today.getMonth() + 1).padStart(2, "0");
+    const dd = String(today.getDate()).padStart(2, "0");
+    expect(toInput.value).toBe(`${yyyy}-${mm}-${dd}`);
+
+    // Start date should be 13 days ago (14-day range inclusive)
+    const start = new Date();
+    start.setDate(start.getDate() - 13);
+    const sy = start.getFullYear();
+    const sm = String(start.getMonth() + 1).padStart(2, "0");
+    const sd = String(start.getDate()).padStart(2, "0");
+    expect(fromInput.value).toBe(`${sy}-${sm}-${sd}`);
+  });
+
+  it("should disable date inputs when 'All dates' is checked", async () => {
+    const user = userEvent.setup();
+    render(() => <ExportDiaryEntries />);
+
+    const allDatesCheckbox = screen.getByLabelText("All dates");
+    const fromInput = screen.getByLabelText("From") as HTMLInputElement;
+    const toInput = screen.getByLabelText("To") as HTMLInputElement;
+
+    expect(fromInput.disabled).toBe(false);
+    expect(toInput.disabled).toBe(false);
+
+    await user.click(allDatesCheckbox);
+
+    expect(fromInput.disabled).toBe(true);
+    expect(toInput.disabled).toBe(true);
+  });
+
+  it("should export with date range variables when date inputs are set", async () => {
+    const user = userEvent.setup();
+    let capturedRequestBody: any;
+
+    server.use(
+      http.post("/api/v1/graphql", async ({ request }) => {
+        capturedRequestBody = await request.json();
+        return HttpResponse.json(exportResponse);
+      }),
+    );
+
+    const { mockCreateObjectURL, mockClick, mockRevokeObjectURL, restore } =
+      mockDownload();
+
+    render(() => <ExportDiaryEntries />);
+
+    const exportButton = screen.getByText("Export As CSV");
+    await user.click(exportButton);
+
+    await waitFor(() => {
+      expect(mockCreateObjectURL).toHaveBeenCalled();
+      expect(mockClick).toHaveBeenCalled();
+      expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+    });
+
+    // Should have sent date range variables as ISO 8601
+    expect(capturedRequestBody.variables).toBeDefined();
+    expect(capturedRequestBody.variables.startDate).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    );
+    expect(capturedRequestBody.variables.endDate).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    );
+
+    restore();
+  });
+
+  it("should export all entries with no date variables when 'All dates' is checked", async () => {
+    const user = userEvent.setup();
+    let capturedRequestBody: any;
+
+    server.use(
+      http.post("/api/v1/graphql", async ({ request }) => {
+        capturedRequestBody = await request.json();
+        return HttpResponse.json(exportResponse);
+      }),
+    );
+
+    const { mockCreateObjectURL, mockClick, mockRevokeObjectURL, restore } =
+      mockDownload();
+
+    render(() => <ExportDiaryEntries />);
+
+    await user.click(screen.getByLabelText("All dates"));
+
+    const exportButton = screen.getByText("Export As CSV");
+    await user.click(exportButton);
+
+    await waitFor(() => {
+      expect(mockCreateObjectURL).toHaveBeenCalled();
+      expect(mockClick).toHaveBeenCalled();
+      expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+    });
+
+    // Should have sent no date range variables
+    expect(capturedRequestBody.variables).toEqual({});
+
+    restore();
+  });
+
+  it("should have a link back to the profile page", () => {
+    render(() => <ExportDiaryEntries />);
+
+    const backLink = screen.getByText("Back to profile");
+    expect(backLink.getAttribute("href")).toBe("/profile");
+  });
+});

--- a/src/ExportDiaryEntries.tsx
+++ b/src/ExportDiaryEntries.tsx
@@ -1,0 +1,107 @@
+import type { Component } from "solid-js";
+import { createSignal } from "solid-js";
+import { useAuth } from "./Auth0";
+import { fetchExportEntries } from "./Api";
+import { entriesToCsv, EntryRecord } from "./CSVExport";
+import ButtonLink from "./ButtonLink";
+
+function toDateInputValue(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function defaultExportStartDate(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 13);
+  return toDateInputValue(d);
+}
+
+function defaultExportEndDate(): string {
+  return toDateInputValue(new Date());
+}
+
+const ExportDiaryEntries: Component = () => {
+  const [{ accessToken }] = useAuth();
+
+  const [exportAllDates, setExportAllDates] = createSignal(false);
+  const [exportStartDate, setExportStartDate] = createSignal(
+    defaultExportStartDate(),
+  );
+  const [exportEndDate, setExportEndDate] = createSignal(
+    defaultExportEndDate(),
+  );
+
+  const handleExport = async (): Promise<void> => {
+    let startDate: string | undefined;
+    let endDate: string | undefined;
+    if (!exportAllDates()) {
+      startDate = new Date(exportStartDate() + "T00:00:00").toISOString();
+      endDate = new Date(exportEndDate() + "T23:59:59.999").toISOString();
+    }
+    const responseData: {
+      data: { food_diary_diary_entry: EntryRecord[] };
+    } = await fetchExportEntries(accessToken(), startDate, endDate);
+    const data: string = entriesToCsv(responseData.data.food_diary_diary_entry);
+    const blob: Blob = new Blob([data], { type: "text/csv" });
+    const url: string = URL.createObjectURL(blob);
+
+    const a: HTMLAnchorElement = document.createElement("a");
+    a.href = url;
+    a.download = "food-diary-entries.csv";
+    a.style.display = "none";
+    document.body.appendChild(a);
+    a.click();
+
+    URL.revokeObjectURL(url);
+    a.remove();
+  };
+
+  return (
+    <div class="flex flex-col">
+      <h1 class="font-semibold text-xl mb-4">Export Entries</h1>
+      <div class="flex flex-col gap-3 max-w-sm">
+        <label class="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={exportAllDates()}
+            onChange={(e) => setExportAllDates(e.currentTarget.checked)}
+          />
+          <span>All dates</span>
+        </label>
+        <label class="flex justify-between items-center">
+          <span>From</span>
+          <input
+            type="date"
+            value={exportStartDate()}
+            disabled={exportAllDates()}
+            onInput={(e) => setExportStartDate(e.currentTarget.value)}
+            class="border border-slate-300 rounded px-2 py-1 disabled:opacity-50"
+          />
+        </label>
+        <label class="flex justify-between items-center">
+          <span>To</span>
+          <input
+            type="date"
+            value={exportEndDate()}
+            disabled={exportAllDates()}
+            onInput={(e) => setExportEndDate(e.currentTarget.value)}
+            class="border border-slate-300 rounded px-2 py-1 disabled:opacity-50"
+          />
+        </label>
+        <button
+          onClick={handleExport}
+          class="bg-indigo-600 text-white rounded px-4 py-2 hover:bg-indigo-700"
+        >
+          Export As CSV
+        </button>
+      </div>
+      <div class="mt-4">
+        <ButtonLink href="/profile">Back to profile</ButtonLink>
+      </div>
+    </div>
+  );
+};
+
+export default ExportDiaryEntries;

--- a/src/UserProfile.test.tsx
+++ b/src/UserProfile.test.tsx
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
-import { server } from "./test-setup";
 import UserProfile from "./UserProfile";
 import { NutritionTargetsProvider } from "./NutritionTargets";
 
@@ -32,17 +30,13 @@ describe("UserProfile", () => {
   it("should display user profile information", () => {
     render(() => <UserProfile />);
 
-    // Check for one of the expected display elements based on our mock
     expect(screen.getByText("test@example.com")).toBeTruthy();
     const img = screen.getByRole("img") as HTMLImageElement;
     expect(img.src).toBe("https://example.com/avatar.jpg");
   });
 
   it("should display name when nickname is not available", () => {
-    // The component displays nickname OR name, our mock has nickname "testuser"
-    // This test verifies the fallback logic exists, but with current mock it shows nickname
     render(() => <UserProfile />);
-    // Just verify component renders
     expect(screen.getByText("test@example.com")).toBeTruthy();
   });
 
@@ -53,71 +47,11 @@ describe("UserProfile", () => {
     expect(importLink.getAttribute("href")).toBe("/diary_entry/import");
   });
 
-  it("should export entries as CSV when button is clicked", async () => {
-    const user = userEvent.setup();
-
-    server.use(
-      http.post("/api/v1/graphql", () => {
-        return HttpResponse.json({
-          data: {
-            food_diary_diary_entry: [
-              {
-                consumed_at: "2024-01-01T10:00:00Z",
-                servings: 1,
-                nutrition_item: {
-                  description: "Apple",
-                  calories: 95,
-                  total_fat_grams: 0.3,
-                  saturated_fat_grams: 0.1,
-                  trans_fat_grams: 0,
-                  polyunsaturated_fat_grams: 0.1,
-                  monounsaturated_fat_grams: 0.1,
-                  cholesterol_mg: 0,
-                  sodium_mg: 2,
-                  total_carbohydrate_grams: 25,
-                  dietary_fiber_grams: 4,
-                  total_sugars_grams: 19,
-                  added_sugars_grams: 0,
-                  protein_grams: 0.5,
-                },
-              },
-            ],
-          },
-        });
-      }),
-    );
-
-    // Mock URL.createObjectURL and URL.revokeObjectURL
-    const mockCreateObjectURL = vi.fn(() => "blob:mock-url");
-    const mockRevokeObjectURL = vi.fn();
-    global.URL.createObjectURL = mockCreateObjectURL;
-    global.URL.revokeObjectURL = mockRevokeObjectURL;
-
-    // Mock document.createElement to track the anchor element
-    const mockAnchor = document.createElement("a");
-    const mockClick = vi.fn();
-    mockAnchor.click = mockClick;
-    const originalCreateElement = document.createElement.bind(document);
-    document.createElement = vi.fn((tag: string) => {
-      if (tag === "a") {
-        return mockAnchor;
-      }
-      return originalCreateElement(tag);
-    }) as any;
-
+  it("should have link to export entries", () => {
     render(() => <UserProfile />);
 
-    const exportButton = screen.getByText("Export Entries As CSV");
-    await user.click(exportButton);
-
-    await waitFor(() => {
-      expect(mockCreateObjectURL).toHaveBeenCalled();
-      expect(mockClick).toHaveBeenCalled();
-      expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
-    });
-
-    // Restore
-    document.createElement = originalCreateElement;
+    const exportLink = screen.getByText("Export Entries");
+    expect(exportLink.getAttribute("href")).toBe("/diary_entry/export");
   });
 
   it("should save daily targets when form is submitted", async () => {
@@ -149,7 +83,6 @@ describe("UserProfile", () => {
     const logoutButton = screen.getByText("Logout");
     await user.click(logoutButton);
 
-    // Just verify the button works - actual logout behavior would be tested in Auth0 integration tests
     expect(logoutButton).toBeTruthy();
   });
 });

--- a/src/UserProfile.tsx
+++ b/src/UserProfile.tsx
@@ -1,8 +1,6 @@
 import type { Component } from "solid-js";
 import { createSignal } from "solid-js";
 import { useAuth } from "./Auth0";
-import { fetchExportEntries } from "./Api";
-import { entriesToCsv, EntryRecord } from "./CSVExport";
 import { useNutritionTargets } from "./NutritionTargets";
 
 type Auth0User = {
@@ -13,7 +11,7 @@ type Auth0User = {
 };
 
 const UserProfile: Component = () => {
-  const [{ user, isAuthenticated, auth0, accessToken }] = useAuth();
+  const [{ user, auth0 }] = useAuth();
   const userObj = (): Auth0User => (user() ?? {}) as Auth0User;
 
   const [targets, updateTargets] = useNutritionTargets();
@@ -111,35 +109,11 @@ const UserProfile: Component = () => {
         </form>
       </div>
 
-      <div class="mt-6 flex flex-col items-center">
-        <a class="ml-3" href="/diary_entry/import">
-          Import Entries
-        </a>
-        <button
-          onClick={async (): Promise<void> => {
-            const responseData: {
-              data: { food_diary_diary_entry: EntryRecord[] };
-            } = await fetchExportEntries(accessToken());
-            const data: string = entriesToCsv(
-              responseData.data.food_diary_diary_entry,
-            );
-            const blob: Blob = new Blob([data], { type: "text/csv" });
-            const url: string = URL.createObjectURL(blob);
-
-            const a: HTMLAnchorElement = document.createElement("a");
-            a.href = url;
-            a.download = "food-diary-entries.csv";
-            a.style.display = "none";
-            document.body.appendChild(a);
-            a.click();
-
-            URL.revokeObjectURL(url);
-            a.remove();
-          }}
-        >
-          Export Entries As CSV
-        </button>
+      <div class="mt-6 flex flex-col gap-2 w-full max-w-sm">
+        <a href="/diary_entry/import">Import Entries</a>
+        <a href="/diary_entry/export">Export Entries</a>
       </div>
+
       <button
         class="text-red-600 mt-4"
         onClick={(): void => {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -20,6 +20,7 @@ vi.mock("./NewRecipeForm", () => ({ default: vi.fn() }));
 vi.mock("./RecipeShow", () => ({ default: vi.fn() }));
 vi.mock("./RecipeEdit", () => ({ default: vi.fn() }));
 vi.mock("./ImportDiaryEntries", () => ({ default: vi.fn() }));
+vi.mock("./ExportDiaryEntries", () => ({ default: vi.fn() }));
 vi.mock("./UserProfile", () => ({ default: vi.fn() }));
 vi.mock("./DiaryEntryEditForm", () => ({ default: vi.fn() }));
 vi.mock("./Trends", () => ({ default: vi.fn() }));

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import NewRecipeForm from "./NewRecipeForm";
 import RecipeShow from "./RecipeShow";
 import RecipeEdit from "./RecipeEdit";
 import ImportDiaryEntries from "./ImportDiaryEntries";
+import ExportDiaryEntries from "./ExportDiaryEntries";
 import UserProfile from "./UserProfile";
 import DiaryEntryEditForm from "./DiaryEntryEditForm";
 import Trends from "./Trends";
@@ -34,6 +35,7 @@ render(
         />
         <Route path="/diary_entry/:id/edit" component={DiaryEntryEditForm} />
         <Route path="/diary_entry/import" component={ImportDiaryEntries} />
+        <Route path="/diary_entry/export" component={ExportDiaryEntries} />
         <Route
           path="/nutrition_item/new"
           component={NewNutritionItemForm as Component}


### PR DESCRIPTION
Moves export functionality from UserProfile to a new ExportDiaryEntries
page at /diary_entry/export. The export form defaults to the last 2 weeks
with "From" / "To" date inputs, or the user can check "All dates" to export
everything. UserProfile now links to both Import and Export pages.

https://claude.ai/code/session_01R3fGea93VdsauQZtuzeDWS