### PR TITLE
ci: add CI and publish workflows for llm-nutrition-api

### DIFF
--- a/.github/workflows/ci-llm-nutrition-api.yml
+++ b/.github/workflows/ci-llm-nutrition-api.yml
@@ -1,0 +1,32 @@
+name: CI (llm-nutrition-api)
+on:
+  push:
+    paths:
+      - "llm-nutrition-api/**"
+  pull_request:
+    paths:
+      - "llm-nutrition-api/**"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: llm-nutrition-api
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            llm-nutrition-api/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('llm-nutrition-api/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Run tests
+        run: cargo test

--- a/.github/workflows/publish-llm-nutrition-api.yml
+++ b/.github/workflows/publish-llm-nutrition-api.yml
@@ -1,0 +1,51 @@
+name: Publish (llm-nutrition-api)
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "llm-nutrition-api-v*"
+    paths:
+      - "llm-nutrition-api/**"
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: bspaulding/food-diary/llm-nutrition-api
+jobs:
+  build-and-publish-image:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            ghcr.io/bspaulding/food-diary/llm-nutrition-api
+          tags: |
+            type=match,pattern=llm-nutrition-api-(v.*),group=1
+            type=ref,event=branch
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: llm-nutrition-api
+          file: llm-nutrition-api/Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            HF_TOKEN=${{ secrets.HF_TOKEN }}


### PR DESCRIPTION
Mirrors the nutrition-fact-labeller pattern exactly:
- ci-llm-nutrition-api.yml: runs cargo test on push/PR to llm-nutrition-api/**
- publish-llm-nutrition-api.yml: builds and pushes to ghcr.io on push to main
  or on tags matching llm-nutrition-api-v*

The publish workflow passes HF_TOKEN as a build arg to the Containerfile's
downloader stage, which downloads the ~3.5 GB Gemma 4 E2B Q5_K_M GGUF from
HuggingFace. Add HF_TOKEN as a repository secret to avoid rate limiting on
large model downloads during CI builds.

https://claude.ai/code/session_01DwNt2EJ9btZT5ED8NQco7y