### PR TITLE
fix: add libclang-dev to llm-nutrition-api container build

### DIFF
--- a/llm-nutrition-api/Containerfile
+++ b/llm-nutrition-api/Containerfile
@@ -5,8 +5,11 @@ FROM public.ecr.aws/docker/library/rust:1.95-bookworm AS builder
 
 WORKDIR /app
 
-# cmake is required by the llama-cpp-2 build script (compiles llama.cpp)
-RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
+# cmake and libclang-dev are required by the llama-cpp-2 build script (compiles llama.cpp via bindgen)
+RUN apt-get update && apt-get install -y \
+    cmake \
+    libclang-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Cache dependency compilation separately from application source
 COPY Cargo.toml Cargo.lock ./


### PR DESCRIPTION
llama-cpp-sys-2 uses bindgen to generate Rust/C++ FFI bindings for
llama.cpp, and bindgen requires libclang at build time. Without it the
build fails immediately with a "couldn't find libclang" error.

nutrition-fact-labeller already had this fix (9c0080b); mirror it here.

https://claude.ai/code/session_015DduG9q958ZyCBmKkgqSqw