### PR TITLE
fix: add --locked to cargo install in container builds

### DIFF
--- a/llm-nutrition-api/Containerfile
+++ b/llm-nutrition-api/Containerfile
@@ -17,7 +17,7 @@ RUN mkdir src && echo "fn main() {}" > src/main.rs
 RUN cargo build --release && rm -rf src
 
 COPY src ./src
-RUN cargo install --path .
+RUN cargo install --path . --locked
 
 # =========================
 # 1. Model download stage

--- a/nutrition-fact-labeller/Containerfile
+++ b/nutrition-fact-labeller/Containerfile
@@ -23,7 +23,7 @@ RUN cargo build --release && rm -rf src
 
 # Copy source and build actual binary
 COPY src ./src
-RUN cargo install --path .
+RUN cargo install --path . --locked
 
 # =========================
 # 1. Model Download stage


### PR DESCRIPTION
cargo install ignores Cargo.lock by default, causing it to resolve
newer dependency versions than the cargo build --release pre-compilation
step. This led to oar-ocr v0.2.2 being compiled against ort v2.0.0-rc.12
(which made Session.inputs/outputs private and changed the SessionBuilder
API) instead of the rc.10 version pinned in Cargo.lock.

https://claude.ai/code/session_01FPPCgHFTJo3qf6vUU6CGLi