### PR TITLE
ci: download paddleocr models in CI with caching

### DIFF
--- a/.github/workflows/ci-nutrition-fact-labeller.yml
+++ b/.github/workflows/ci-nutrition-fact-labeller.yml
@@ -29,12 +29,14 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache paddleocr models
+        id: cache-paddleocr-models
         uses: actions/cache@v4
         with:
           path: nutrition-fact-labeller/paddleocr-models
           key: paddleocr-models-v0.1.0
 
       - name: Download paddleocr models
+        if: steps.cache-paddleocr-models.outputs.cache-hit != 'true'
         run: |
           mkdir -p paddleocr-models
           curl -L --output paddleocr-models/ppocrv4_mobile_det.onnx https://github.com/GreatV/oar-ocr/releases/download/v0.1.0/ppocrv4_mobile_det.onnx

--- a/.github/workflows/ci-nutrition-fact-labeller.yml
+++ b/.github/workflows/ci-nutrition-fact-labeller.yml
@@ -28,5 +28,21 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('nutrition-fact-labeller/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
+      - name: Cache paddleocr models
+        uses: actions/cache@v4
+        with:
+          path: nutrition-fact-labeller/paddleocr-models
+          key: paddleocr-models-v0.1.0
+
+      - name: Download paddleocr models
+        run: |
+          mkdir -p paddleocr-models
+          BASE=https://github.com/GreatV/oar-ocr/releases/download/v0.1.0
+          for f in ppocrv4_mobile_det.onnx en_ppocrv4_mobile_rec.onnx en_dict.txt pplcnet_x1_0_doc_ori.onnx pplcnet_x1_0_textline_ori.onnx uvdoc.onnx; do
+            if [ ! -f "paddleocr-models/$f" ]; then
+              curl -fsSL --output "paddleocr-models/$f" "$BASE/$f"
+            fi
+          done
+
       - name: Run tests
         run: cargo test

--- a/.github/workflows/ci-nutrition-fact-labeller.yml
+++ b/.github/workflows/ci-nutrition-fact-labeller.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Download paddleocr models
         run: |
           mkdir -p paddleocr-models
-          BASE=https://github.com/GreatV/oar-ocr/releases/download/v0.1.0
-          for f in ppocrv4_mobile_det.onnx en_ppocrv4_mobile_rec.onnx en_dict.txt pplcnet_x1_0_doc_ori.onnx pplcnet_x1_0_textline_ori.onnx uvdoc.onnx; do
-            if [ ! -f "paddleocr-models/$f" ]; then
-              curl -fsSL --output "paddleocr-models/$f" "$BASE/$f"
-            fi
-          done
+          curl -L --output paddleocr-models/ppocrv4_mobile_det.onnx https://github.com/GreatV/oar-ocr/releases/download/v0.1.0/ppocrv4_mobile_det.onnx
+          curl -L --output paddleocr-models/en_ppocrv4_mobile_rec.onnx https://github.com/GreatV/oar-ocr/releases/download/v0.1.0/en_ppocrv4_mobile_rec.onnx
+          curl -L --output paddleocr-models/en_dict.txt https://github.com/GreatV/oar-ocr/releases/download/v0.1.0/en_dict.txt
+          curl -L --output paddleocr-models/pplcnet_x1_0_doc_ori.onnx https://github.com/GreatV/oar-ocr/releases/download/v0.1.0/pplcnet_x1_0_doc_ori.onnx
+          curl -L --output paddleocr-models/pplcnet_x1_0_textline_ori.onnx https://github.com/GreatV/oar-ocr/releases/download/v0.1.0/pplcnet_x1_0_textline_ori.onnx
+          curl -L --output paddleocr-models/uvdoc.onnx https://github.com/GreatV/oar-ocr/releases/download/v0.1.0/uvdoc.onnx
 
       - name: Run tests
         run: cargo test


### PR DESCRIPTION
The check_test_cases test requires ONNX model files that aren't
committed to the repo. Download them from the oar-ocr GitHub release
(same source used in the Containerfile) and cache them between runs.

https://claude.ai/code/session_0146AA9ZJzk6CsdPtcqisRmU