### PR TITLE
Add OpenRouter backend support with configurable mode selection

### DIFF
--- a/llm-nutrition-api/Cargo.lock
+++ b/llm-nutrition-api/Cargo.lock
@@ -1410,6 +1410,7 @@ dependencies = [
 name = "llm-nutrition-api"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "dom_smoothie",
  "encoding_rs",
  "env_logger",

--- a/llm-nutrition-api/Cargo.toml
+++ b/llm-nutrition-api/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+clap = { version = "4", features = ["derive"] }
 dom_smoothie = "0.17"
 encoding_rs = "0.8"
 env_logger = "0.11"

--- a/llm-nutrition-api/src/agent.rs
+++ b/llm-nutrition-api/src/agent.rs
@@ -12,6 +12,7 @@ use crate::NutritionItem;
 
 const MAX_ROUNDS: usize = 5;
 const MAX_NEW_TOKENS: usize = 1024;
+const OPENROUTER_MAX_RETRIES: u32 = 4;
 
 const SYSTEM_PROMPT: &str = "\
 You are a nutrition expert. Look up or estimate nutritional values for the food the user describes.
@@ -214,28 +215,49 @@ async fn call_openrouter(
         "max_tokens": MAX_NEW_TOKENS
     });
 
-    let response = client
-        .post("https://openrouter.ai/api/v1/chat/completions")
-        .header("Authorization", format!("Bearer {api_key}"))
-        .header("Content-Type", "application/json")
-        .json(&body)
-        .send()
-        .await?;
+    let mut attempt = 0u32;
+    loop {
+        let response = client
+            .post("https://openrouter.ai/api/v1/chat/completions")
+            .header("Authorization", format!("Bearer {api_key}"))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
 
-    if !response.status().is_success() {
-        let status = response.status();
-        let text = response.text().await.unwrap_or_default();
-        return Err(format!("OpenRouter API error {status}: {text}").into());
+        if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            if attempt >= OPENROUTER_MAX_RETRIES {
+                let text = response.text().await.unwrap_or_default();
+                return Err(format!("OpenRouter rate limit exceeded after {attempt} retries: {text}").into());
+            }
+            // Respect Retry-After if provided, otherwise exponential backoff (1s, 2s, 4s, 8s).
+            let delay_secs = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(1u64 << attempt);
+            log::warn!("OpenRouter 429 on attempt {attempt}, retrying in {delay_secs}s");
+            tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+            attempt += 1;
+            continue;
+        }
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!("OpenRouter API error {status}: {text}").into());
+        }
+
+        let json: serde_json::Value = response.json().await?;
+        let content = json["choices"][0]["message"]["content"]
+            .as_str()
+            .ok_or("Missing content in OpenRouter response")?
+            .trim()
+            .to_string();
+
+        return Ok(content);
     }
-
-    let json: serde_json::Value = response.json().await?;
-    let content = json["choices"][0]["message"]["content"]
-        .as_str()
-        .ok_or("Missing content in OpenRouter response")?
-        .trim()
-        .to_string();
-
-    Ok(content)
 }
 
 async fn run_agent_local(

--- a/llm-nutrition-api/src/agent.rs
+++ b/llm-nutrition-api/src/agent.rs
@@ -12,7 +12,6 @@ use crate::NutritionItem;
 
 const MAX_ROUNDS: usize = 5;
 const MAX_NEW_TOKENS: usize = 1024;
-const OPENROUTER_MODEL: &str = "google/gemma-4-31b-it:free";
 
 const SYSTEM_PROMPT: &str = "\
 You are a nutrition expert. Look up or estimate nutritional values for the food the user describes.
@@ -73,6 +72,7 @@ pub enum BackendConfig {
     },
     OpenRouter {
         api_key: String,
+        model: String,
         client: reqwest::Client,
     },
 }
@@ -195,6 +195,7 @@ fn extract_json(text: &str) -> Option<&str> {
 async fn call_openrouter(
     client: &reqwest::Client,
     api_key: &str,
+    model: &str,
     conversation: &[(String, String)],
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let messages: Vec<serde_json::Value> = conversation
@@ -207,7 +208,7 @@ async fn call_openrouter(
         .collect();
 
     let body = serde_json::json!({
-        "model": OPENROUTER_MODEL,
+        "model": model,
         "messages": messages,
         "temperature": 0.1,
         "max_tokens": MAX_NEW_TOKENS
@@ -324,6 +325,7 @@ async fn run_agent_local(
 async fn run_agent_openrouter(
     client: &reqwest::Client,
     api_key: &str,
+    model: &str,
     description: String,
 ) -> Result<NutritionItem, Box<dyn std::error::Error + Send + Sync>> {
     let mut conversation: Vec<(String, String)> = vec![
@@ -334,7 +336,7 @@ async fn run_agent_openrouter(
     for round in 0..MAX_ROUNDS {
         log::debug!("Agent round {round}");
 
-        let output = call_openrouter(client, api_key, &conversation).await?;
+        let output = call_openrouter(client, api_key, model, &conversation).await?;
         log::debug!("Model output: {output}");
 
         let json_str = extract_json(&output).unwrap_or(&output);
@@ -378,7 +380,7 @@ async fn run_agent_openrouter(
             "Output ONLY the JSON nutrition object. No markdown, no explanation, just the JSON object with all 14 fields.".to_string(),
         ));
 
-        let final_json = call_openrouter(client, api_key, &final_conv).await?;
+        let final_json = call_openrouter(client, api_key, model, &final_conv).await?;
         log::debug!("Final JSON: {final_json}");
 
         let json_str = extract_json(&final_json).unwrap_or(&final_json);
@@ -397,8 +399,8 @@ pub async fn run_agent(
         BackendConfig::Local { backend, model } => {
             run_agent_local(Arc::clone(backend), Arc::clone(model), description).await
         }
-        BackendConfig::OpenRouter { api_key, client } => {
-            run_agent_openrouter(client, api_key, description).await
+        BackendConfig::OpenRouter { api_key, model, client } => {
+            run_agent_openrouter(client, api_key, model, description).await
         }
     }
 }

--- a/llm-nutrition-api/src/agent.rs
+++ b/llm-nutrition-api/src/agent.rs
@@ -12,6 +12,7 @@ use crate::NutritionItem;
 
 const MAX_ROUNDS: usize = 5;
 const MAX_NEW_TOKENS: usize = 1024;
+const OPENROUTER_MODEL: &str = "google/gemma-4-31b-it:free";
 
 const SYSTEM_PROMPT: &str = "\
 You are a nutrition expert. Look up or estimate nutritional values for the food the user describes.
@@ -63,6 +64,17 @@ struct ToolCall {
     query: String,
     #[serde(default)]
     url: String,
+}
+
+pub enum BackendConfig {
+    Local {
+        backend: Arc<LlamaBackend>,
+        model: Arc<LlamaModel>,
+    },
+    OpenRouter {
+        api_key: String,
+        client: reqwest::Client,
+    },
 }
 
 // Build a Gemma-formatted prompt from a message history.
@@ -180,7 +192,52 @@ fn extract_json(text: &str) -> Option<&str> {
     Some(&slice[..=end])
 }
 
-pub async fn run_agent(
+async fn call_openrouter(
+    client: &reqwest::Client,
+    api_key: &str,
+    conversation: &[(String, String)],
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let messages: Vec<serde_json::Value> = conversation
+        .iter()
+        .map(|(role, content)| {
+            // OpenAI format doesn't have a "tool" role in this simple usage; treat as user.
+            let api_role = if role == "tool" { "user" } else { role.as_str() };
+            serde_json::json!({ "role": api_role, "content": content })
+        })
+        .collect();
+
+    let body = serde_json::json!({
+        "model": OPENROUTER_MODEL,
+        "messages": messages,
+        "temperature": 0.1,
+        "max_tokens": MAX_NEW_TOKENS
+    });
+
+    let response = client
+        .post("https://openrouter.ai/api/v1/chat/completions")
+        .header("Authorization", format!("Bearer {api_key}"))
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("OpenRouter API error {status}: {text}").into());
+    }
+
+    let json: serde_json::Value = response.json().await?;
+    let content = json["choices"][0]["message"]["content"]
+        .as_str()
+        .ok_or("Missing content in OpenRouter response")?
+        .trim()
+        .to_string();
+
+    Ok(content)
+}
+
+async fn run_agent_local(
     backend: Arc<LlamaBackend>,
     model: Arc<LlamaModel>,
     description: String,
@@ -204,7 +261,6 @@ pub async fn run_agent(
 
         log::debug!("Model output: {output}");
 
-        // Try to parse as a tool call
         let json_str = extract_json(&output).unwrap_or(&output);
         if let Ok(call) = serde_json::from_str::<ToolCall>(json_str) {
             match call.action.as_str() {
@@ -263,4 +319,86 @@ pub async fn run_agent(
     }
 
     Err("Max agent rounds exceeded without a nutrition answer".into())
+}
+
+async fn run_agent_openrouter(
+    client: &reqwest::Client,
+    api_key: &str,
+    description: String,
+) -> Result<NutritionItem, Box<dyn std::error::Error + Send + Sync>> {
+    let mut conversation: Vec<(String, String)> = vec![
+        ("system".to_string(), SYSTEM_PROMPT.to_string()),
+        ("user".to_string(), description),
+    ];
+
+    for round in 0..MAX_ROUNDS {
+        log::debug!("Agent round {round}");
+
+        let output = call_openrouter(client, api_key, &conversation).await?;
+        log::debug!("Model output: {output}");
+
+        let json_str = extract_json(&output).unwrap_or(&output);
+        if let Ok(call) = serde_json::from_str::<ToolCall>(json_str) {
+            match call.action.as_str() {
+                "search_web" if !call.query.is_empty() => {
+                    log::info!("Tool call: search_web({:?})", call.query);
+                    let result = match crate::tools::search_web(&call.query).await {
+                        Ok(r) => format!("Search results for '{}':\n{r}", call.query),
+                        Err(e) => {
+                            log::warn!("search_web failed: {e}");
+                            format!("Search failed: {e}. Estimate from nutritional knowledge instead.")
+                        }
+                    };
+                    conversation.push(("assistant".to_string(), output));
+                    conversation.push(("tool".to_string(), result));
+                    continue;
+                }
+                "read_webpage" if !call.url.is_empty() => {
+                    log::info!("Tool call: read_webpage({:?})", call.url);
+                    let result = match crate::tools::read_webpage(&call.url).await {
+                        Ok(r) => format!("Page content from {}:\n{r}", call.url),
+                        Err(e) => {
+                            log::warn!("read_webpage failed: {e}");
+                            format!("Page fetch failed: {e}. Estimate from nutritional knowledge instead.")
+                        }
+                    };
+                    conversation.push(("assistant".to_string(), output));
+                    conversation.push(("tool".to_string(), result));
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
+        // No tool call — final pass requesting pure JSON.
+        let mut final_conv = conversation.clone();
+        final_conv.push(("assistant".to_string(), output));
+        final_conv.push((
+            "user".to_string(),
+            "Output ONLY the JSON nutrition object. No markdown, no explanation, just the JSON object with all 14 fields.".to_string(),
+        ));
+
+        let final_json = call_openrouter(client, api_key, &final_conv).await?;
+        log::debug!("Final JSON: {final_json}");
+
+        let json_str = extract_json(&final_json).unwrap_or(&final_json);
+        let item: NutritionItem = serde_json::from_str(json_str)?;
+        return Ok(item);
+    }
+
+    Err("Max agent rounds exceeded without a nutrition answer".into())
+}
+
+pub async fn run_agent(
+    config: Arc<BackendConfig>,
+    description: String,
+) -> Result<NutritionItem, Box<dyn std::error::Error + Send + Sync>> {
+    match config.as_ref() {
+        BackendConfig::Local { backend, model } => {
+            run_agent_local(Arc::clone(backend), Arc::clone(model), description).await
+        }
+        BackendConfig::OpenRouter { api_key, client } => {
+            run_agent_openrouter(client, api_key, description).await
+        }
+    }
 }

--- a/llm-nutrition-api/src/main.rs
+++ b/llm-nutrition-api/src/main.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use log::info;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -44,29 +45,92 @@ struct ErrorResponse {
 }
 
 pub struct AppState {
-    pub backend: Arc<LlamaBackend>,
-    pub model: Arc<LlamaModel>,
+    pub config: Arc<agent::BackendConfig>,
+}
+
+#[derive(Parser)]
+#[command(about = "LLM-powered nutrition lookup API")]
+struct Args {
+    /// Backend to use: 'local' (llama.cpp + GEMMA_MODEL_PATH) or 'openrouter'
+    /// (OPENROUTER_API_KEY). When omitted, defaults to openrouter if
+    /// OPENROUTER_API_KEY is set, then local if GEMMA_MODEL_PATH is set.
+    #[arg(long, value_enum)]
+    mode: Option<CliMode>,
+}
+
+#[derive(Clone, clap::ValueEnum)]
+enum CliMode {
+    Local,
+    Openrouter,
+}
+
+fn load_local_model(path: String) -> Arc<agent::BackendConfig> {
+    info!("Loading local model from {path}");
+    let backend = LlamaBackend::init().expect("Failed to initialize llama backend");
+    let model_params = LlamaModelParams::default();
+    let model = LlamaModel::load_from_file(&backend, &path, &model_params)
+        .expect("Failed to load model");
+    info!("Local model loaded successfully");
+    Arc::new(agent::BackendConfig::Local {
+        backend: Arc::new(backend),
+        model: Arc::new(model),
+    })
+}
+
+fn build_config(mode: Option<CliMode>) -> Arc<agent::BackendConfig> {
+    let openrouter_key = std::env::var("OPENROUTER_API_KEY").ok();
+    let model_path = std::env::var("GEMMA_MODEL_PATH").ok();
+
+    match mode {
+        Some(CliMode::Openrouter) => {
+            let key = openrouter_key.unwrap_or_else(|| {
+                eprintln!("--mode openrouter requires OPENROUTER_API_KEY to be set");
+                std::process::exit(1);
+            });
+            info!("Using OpenRouter backend (google/gemma-4-31b-it:free)");
+            Arc::new(agent::BackendConfig::OpenRouter {
+                api_key: key,
+                client: reqwest::Client::new(),
+            })
+        }
+        Some(CliMode::Local) => {
+            let path = model_path.unwrap_or_else(|| {
+                eprintln!("--mode local requires GEMMA_MODEL_PATH to be set");
+                std::process::exit(1);
+            });
+            load_local_model(path)
+        }
+        None => {
+            if let Some(key) = openrouter_key {
+                info!("Auto-selected OpenRouter backend (OPENROUTER_API_KEY is set)");
+                Arc::new(agent::BackendConfig::OpenRouter {
+                    api_key: key,
+                    client: reqwest::Client::new(),
+                })
+            } else if let Some(path) = model_path {
+                info!("Auto-selected local model backend (GEMMA_MODEL_PATH is set)");
+                load_local_model(path)
+            } else {
+                eprintln!(
+                    "No backend configured. Either:\n  \
+                     - Set OPENROUTER_API_KEY to use OpenRouter (google/gemma-4-31b-it:free)\n  \
+                     - Set GEMMA_MODEL_PATH to use the local Gemma model\n  \
+                     - Pass --mode local|openrouter to force a specific backend"
+                );
+                std::process::exit(1);
+            }
+        }
+    }
 }
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
+    let args = Args::parse();
 
-    let model_path = std::env::var("GEMMA_MODEL_PATH")
-        .expect("GEMMA_MODEL_PATH must be set to the path of the Gemma 4 E2B GGUF file");
+    let config = build_config(args.mode);
 
-    info!("Loading model from {model_path}");
-    let backend = LlamaBackend::init().expect("Failed to initialize llama backend");
-    let model_params = LlamaModelParams::default();
-    let model = LlamaModel::load_from_file(&backend, &model_path, &model_params)
-        .expect("Failed to load model");
-    info!("Model loaded successfully");
-
-    let state = Arc::new(AppState {
-        backend: Arc::new(backend),
-        model: Arc::new(model),
-    });
-
+    let state = Arc::new(AppState { config });
     let state_filter = warp::any().map(move || Arc::clone(&state));
 
     let lookup = warp::post()
@@ -88,19 +152,11 @@ async fn handle_lookup(
     req: LookupRequest,
     state: Arc<AppState>,
 ) -> Result<impl warp::Reply, warp::Rejection> {
-    let reply = match agent::run_agent(
-        Arc::clone(&state.backend),
-        Arc::clone(&state.model),
-        req.description,
-    )
-    .await
-    {
-        Ok(item) => {
-            warp::reply::with_status(
-                warp::reply::json(&LookupResponse { item }),
-                warp::http::StatusCode::OK,
-            )
-        }
+    let reply = match agent::run_agent(Arc::clone(&state.config), req.description).await {
+        Ok(item) => warp::reply::with_status(
+            warp::reply::json(&LookupResponse { item }),
+            warp::http::StatusCode::OK,
+        ),
         Err(e) => {
             log::error!("Agent error: {e}");
             warp::reply::with_status(

--- a/llm-nutrition-api/src/main.rs
+++ b/llm-nutrition-api/src/main.rs
@@ -77,8 +77,12 @@ fn load_local_model(path: String) -> Arc<agent::BackendConfig> {
     })
 }
 
+const DEFAULT_OPENROUTER_MODEL: &str = "google/gemma-4-31b-it:free";
+
 fn build_config(mode: Option<CliMode>) -> Arc<agent::BackendConfig> {
     let openrouter_key = std::env::var("OPENROUTER_API_KEY").ok();
+    let openrouter_model = std::env::var("OPENROUTER_MODEL")
+        .unwrap_or_else(|_| DEFAULT_OPENROUTER_MODEL.to_string());
     let model_path = std::env::var("GEMMA_MODEL_PATH").ok();
 
     match mode {
@@ -87,9 +91,10 @@ fn build_config(mode: Option<CliMode>) -> Arc<agent::BackendConfig> {
                 eprintln!("--mode openrouter requires OPENROUTER_API_KEY to be set");
                 std::process::exit(1);
             });
-            info!("Using OpenRouter backend (google/gemma-4-31b-it:free)");
+            info!("Using OpenRouter backend ({openrouter_model})");
             Arc::new(agent::BackendConfig::OpenRouter {
                 api_key: key,
+                model: openrouter_model,
                 client: reqwest::Client::new(),
             })
         }
@@ -102,9 +107,10 @@ fn build_config(mode: Option<CliMode>) -> Arc<agent::BackendConfig> {
         }
         None => {
             if let Some(key) = openrouter_key {
-                info!("Auto-selected OpenRouter backend (OPENROUTER_API_KEY is set)");
+                info!("Auto-selected OpenRouter backend ({openrouter_model})");
                 Arc::new(agent::BackendConfig::OpenRouter {
                     api_key: key,
+                    model: openrouter_model,
                     client: reqwest::Client::new(),
                 })
             } else if let Some(path) = model_path {
@@ -113,9 +119,10 @@ fn build_config(mode: Option<CliMode>) -> Arc<agent::BackendConfig> {
             } else {
                 eprintln!(
                     "No backend configured. Either:\n  \
-                     - Set OPENROUTER_API_KEY to use OpenRouter (google/gemma-4-31b-it:free)\n  \
+                     - Set OPENROUTER_API_KEY to use OpenRouter (default: {DEFAULT_OPENROUTER_MODEL})\n  \
                      - Set GEMMA_MODEL_PATH to use the local Gemma model\n  \
-                     - Pass --mode local|openrouter to force a specific backend"
+                     - Pass --mode local|openrouter to force a specific backend\n  \
+                     - Set OPENROUTER_MODEL to override the OpenRouter model"
                 );
                 std::process::exit(1);
             }


### PR DESCRIPTION
## Summary
This PR adds support for using OpenRouter as an alternative backend to the local Llama model, with intelligent auto-detection and explicit mode selection via CLI flags.

## Key Changes

- **New `BackendConfig` enum**: Abstracts backend selection between local Llama and OpenRouter, allowing the agent to work with either backend transparently.

- **OpenRouter integration**:
  - Added `call_openrouter()` function to handle API calls with automatic retry logic for rate limiting (429 responses)
  - Implements exponential backoff with respect for `Retry-After` headers
  - Configurable max retries via `OPENROUTER_MAX_RETRIES` constant (set to 4)
  - Added `run_agent_openrouter()` function mirroring the local agent logic

- **Refactored agent execution**:
  - Renamed original `run_agent()` to `run_agent_local()` for clarity
  - New `run_agent()` dispatcher that routes to the appropriate backend based on `BackendConfig`

- **CLI mode selection**:
  - Added `clap` dependency for argument parsing
  - New `--mode` flag to explicitly select `local` or `openrouter` backend
  - Auto-detection logic: prefers OpenRouter if `OPENROUTER_API_KEY` is set, falls back to local if `GEMMA_MODEL_PATH` is set
  - New `OPENROUTER_MODEL` environment variable to override the default model (`google/gemma-4-31b-it:free`)

- **AppState refactoring**: Changed from storing separate `backend` and `model` fields to a single `config` field of type `Arc<BackendConfig>`.

## Notable Implementation Details

- OpenRouter API calls use OpenAI-compatible format with message history
- Tool role handling: converts "tool" role to "user" for OpenRouter compatibility
- Rate limiting respects the `Retry-After` header when available, otherwise uses exponential backoff (1s, 2s, 4s, 8s)
- Both backends share the same tool-calling and JSON extraction logic
- Graceful error messages guide users to configure the required environment variables or CLI flags

https://claude.ai/code/session_015fKonTkeJWfBvpdLkcmtxU