### PR TITLE
Switch LLM backend from OpenRouter to Google AI direct

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,12 +7,18 @@ HASURA_GRAPHQL_JWT_SECRET=
 # Download: huggingface-cli download bartowski/google_gemma-4-E2B-it-GGUF google_gemma-4-E2B-it-Q5_K_M.gguf --local-dir /path/to/models --local-dir-use-symlinks False
 GEMMA_MODEL_PATH=/path/to/models/google_gemma-4-E2B-it-Q5_K_M.gguf
 
-# Optional: enable the VLM backend in the nutrition-fact-labeller service.
-# OpenRouter is tried first if its key is set; local llama.cpp is the fallback.
+# Optional: enable the remote LLM/VLM backend (used by both services).
+# LLM_API_KEY is tried first; OPENROUTER_API_KEY is accepted as a fallback.
+# Default model: gemini-2.0-flash via Google AI's OpenAI-compatible endpoint.
 
-# Option A: OpenRouter (no local model weights required)
+# Option A: Google AI direct (recommended — no proxy, better reliability)
+# LLM_API_KEY=AIza...          # Google AI Studio key (aistudio.google.com/apikey)
+# LLM_MODEL=gemini-2.0-flash   # optional; gemini-2.0-flash is the default
+# LLM_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai  # optional
+
+# Option A (legacy): OpenRouter — OPENROUTER_* vars still work as fallbacks
 # OPENROUTER_API_KEY=sk-or-v1-...
-# OPENROUTER_MODEL=google/gemma-4-31b-it:free   # default; any OpenRouter vision model works
+# OPENROUTER_MODEL=google/gemini-2.0-flash-001
 
 # Option B: local llama.cpp (both must be set together)
 # VLM_MODEL_PATH can point at the same file as GEMMA_MODEL_PATH.

--- a/llm-nutrition-api/eval/results/gemini-2.5-flash/2026-05-25.json
+++ b/llm-nutrition-api/eval/results/gemini-2.5-flash/2026-05-25.json
@@ -1,0 +1,2458 @@
+{
+  "date": "2026-05-25",
+  "base_url": "http://localhost:3031",
+  "results": [
+    {
+      "id": "egg-large-raw",
+      "query": "1 large egg (50g), raw",
+      "category": "whole_food",
+      "elapsed_seconds": 3.4,
+      "status": "ok",
+      "predicted_description": "1 large egg (50g), raw",
+      "errors": {
+        "calories": {
+          "predicted": 72.0,
+          "ground_truth": 72,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_fat_grams": {
+          "predicted": 4.8,
+          "ground_truth": 4.8,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 1.6,
+          "ground_truth": 1.6,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 0.7,
+          "ground_truth": 1.0,
+          "abs_error": 0.3,
+          "rel_error_pct": 30.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 1.9,
+          "ground_truth": 1.8,
+          "abs_error": 0.1,
+          "rel_error_pct": 5.6
+        },
+        "cholesterol_milligrams": {
+          "predicted": 186.0,
+          "ground_truth": 186,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 70.0,
+          "ground_truth": 71,
+          "abs_error": 1.0,
+          "rel_error_pct": 1.4
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 0.6,
+          "ground_truth": 0.4,
+          "abs_error": 0.2,
+          "rel_error_pct": 20.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 0.6,
+          "ground_truth": 0.2,
+          "abs_error": 0.4,
+          "rel_error_pct": 40.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 6.3,
+          "ground_truth": 6.3,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "chicken-breast-cooked",
+      "query": "100g grilled chicken breast, no skin",
+      "category": "whole_food",
+      "elapsed_seconds": 9.9,
+      "status": "ok",
+      "predicted_description": "",
+      "errors": {
+        "calories": {
+          "predicted": 0.0,
+          "ground_truth": 165,
+          "abs_error": 165.0,
+          "rel_error_pct": 100.0
+        },
+        "total_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 3.6,
+          "abs_error": 3.6,
+          "rel_error_pct": 100.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 1.0,
+          "abs_error": 1.0,
+          "rel_error_pct": 100.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0.8,
+          "abs_error": 0.8,
+          "rel_error_pct": 80.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 1.2,
+          "abs_error": 1.2,
+          "rel_error_pct": 100.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 85,
+          "abs_error": 85.0,
+          "rel_error_pct": 100.0
+        },
+        "sodium_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 74,
+          "abs_error": 74.0,
+          "rel_error_pct": 100.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 0.0,
+          "ground_truth": 31.0,
+          "abs_error": 31.0,
+          "rel_error_pct": 100.0
+        }
+      },
+      "within_tolerance": {
+        "calories": false,
+        "total_fat_grams": false,
+        "total_carbohydrate_grams": true,
+        "protein_grams": false
+      }
+    },
+    {
+      "id": "oatmeal-cooked",
+      "query": "1 cup cooked plain oatmeal (234g)",
+      "category": "whole_food",
+      "elapsed_seconds": 4.0,
+      "status": "ok",
+      "predicted_description": "1 cup cooked plain oatmeal",
+      "errors": {
+        "calories": {
+          "predicted": 166.0,
+          "ground_truth": 166,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_fat_grams": {
+          "predicted": 3.6,
+          "ground_truth": 3.6,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 0.7,
+          "ground_truth": 0.7,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 1.3,
+          "ground_truth": 1.3,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 1.1,
+          "ground_truth": 1.1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 115.0,
+          "ground_truth": 115,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 28.0,
+          "ground_truth": 28.1,
+          "abs_error": 0.1,
+          "rel_error_pct": 0.4
+        },
+        "dietary_fiber_grams": {
+          "predicted": 4.0,
+          "ground_truth": 4.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 0.6,
+          "ground_truth": 0.6,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 5.9,
+          "ground_truth": 5.9,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "banana-medium",
+      "query": "1 medium banana (118g)",
+      "category": "whole_food",
+      "elapsed_seconds": 5.2,
+      "status": "ok",
+      "predicted_description": "1 medium banana",
+      "errors": {
+        "calories": {
+          "predicted": 105.0,
+          "ground_truth": 105,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_fat_grams": {
+          "predicted": 0.4,
+          "ground_truth": 0.4,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 0.1,
+          "ground_truth": 0.1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 0.1,
+          "ground_truth": 0.1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 1.0,
+          "ground_truth": 1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 27.0,
+          "ground_truth": 27.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 3.1,
+          "ground_truth": 3.1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 14.4,
+          "ground_truth": 14.4,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 1.3,
+          "ground_truth": 1.3,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "whole-milk-cup",
+      "query": "1 cup whole milk (244g)",
+      "category": "whole_food",
+      "elapsed_seconds": 4.8,
+      "status": "ok",
+      "predicted_description": "1 cup whole milk",
+      "errors": {
+        "calories": {
+          "predicted": 150.0,
+          "ground_truth": 149,
+          "abs_error": 1.0,
+          "rel_error_pct": 0.7
+        },
+        "total_fat_grams": {
+          "predicted": 8.0,
+          "ground_truth": 8.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 5.0,
+          "ground_truth": 4.6,
+          "abs_error": 0.4,
+          "rel_error_pct": 8.7
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 0.5,
+          "ground_truth": 0.3,
+          "abs_error": 0.2,
+          "rel_error_pct": 20.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 2.0,
+          "ground_truth": 2.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 24.0,
+          "ground_truth": 24,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 100.0,
+          "ground_truth": 105,
+          "abs_error": 5.0,
+          "rel_error_pct": 4.8
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 12.0,
+          "ground_truth": 11.7,
+          "abs_error": 0.3,
+          "rel_error_pct": 2.6
+        },
+        "dietary_fiber_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 12.0,
+          "ground_truth": 12.3,
+          "abs_error": 0.3,
+          "rel_error_pct": 2.4
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 8.0,
+          "ground_truth": 7.7,
+          "abs_error": 0.3,
+          "rel_error_pct": 3.9
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "white-rice-cooked",
+      "query": "100g cooked white rice",
+      "category": "whole_food",
+      "elapsed_seconds": 3.5,
+      "status": "ok",
+      "predicted_description": "100g cooked white rice",
+      "errors": {
+        "calories": {
+          "predicted": 130.0,
+          "ground_truth": 130,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_fat_grams": {
+          "predicted": 0.3,
+          "ground_truth": 0.3,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 0.1,
+          "ground_truth": 0.1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 0.1,
+          "ground_truth": 0.1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 0.1,
+          "ground_truth": 0.1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 1.0,
+          "ground_truth": 1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 28.2,
+          "ground_truth": 28.2,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 0.4,
+          "ground_truth": 0.4,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 2.7,
+          "ground_truth": 2.7,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "broccoli-raw",
+      "query": "100g raw broccoli",
+      "category": "whole_food",
+      "elapsed_seconds": 4.8,
+      "status": "ok",
+      "predicted_description": "100g raw broccoli",
+      "errors": {
+        "calories": {
+          "predicted": 34.0,
+          "ground_truth": 34,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_fat_grams": {
+          "predicted": 0.4,
+          "ground_truth": 0.4,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 0.04,
+          "ground_truth": 0.0,
+          "abs_error": 0.04,
+          "rel_error_pct": 4.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 0.14,
+          "ground_truth": 0.0,
+          "abs_error": 0.14,
+          "rel_error_pct": 14.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 0.02,
+          "ground_truth": 0.0,
+          "abs_error": 0.02,
+          "rel_error_pct": 2.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 33.0,
+          "ground_truth": 33,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 6.6,
+          "ground_truth": 6.6,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 2.6,
+          "ground_truth": 2.6,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 1.7,
+          "ground_truth": 1.7,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 2.8,
+          "ground_truth": 2.8,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "olive-oil-tbsp",
+      "query": "1 tablespoon olive oil (14g)",
+      "category": "whole_food",
+      "elapsed_seconds": 3.8,
+      "status": "ok",
+      "predicted_description": "1 tablespoon olive oil",
+      "errors": {
+        "calories": {
+          "predicted": 120.0,
+          "ground_truth": 119,
+          "abs_error": 1.0,
+          "rel_error_pct": 0.8
+        },
+        "total_fat_grams": {
+          "predicted": 14.0,
+          "ground_truth": 13.5,
+          "abs_error": 0.5,
+          "rel_error_pct": 3.7
+        },
+        "saturated_fat_grams": {
+          "predicted": 2.0,
+          "ground_truth": 1.9,
+          "abs_error": 0.1,
+          "rel_error_pct": 5.3
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 1.5,
+          "ground_truth": 1.4,
+          "abs_error": 0.1,
+          "rel_error_pct": 7.1
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 10.0,
+          "ground_truth": 9.9,
+          "abs_error": 0.1,
+          "rel_error_pct": 1.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "scrambled-eggs-2",
+      "query": "2 scrambled eggs with butter",
+      "category": "composite_meal",
+      "elapsed_seconds": 16.0,
+      "status": "ok",
+      "predicted_description": "2 scrambled eggs with butter",
+      "errors": {
+        "calories": {
+          "predicted": 184.0,
+          "ground_truth": 200,
+          "abs_error": 16.0,
+          "rel_error_pct": 8.0
+        },
+        "total_fat_grams": {
+          "predicted": 13.6,
+          "ground_truth": 15.0,
+          "abs_error": 1.4,
+          "rel_error_pct": 9.3
+        },
+        "saturated_fat_grams": {
+          "predicted": 5.0,
+          "ground_truth": 5.5,
+          "abs_error": 0.5,
+          "rel_error_pct": 9.1
+        },
+        "trans_fat_grams": {
+          "predicted": 0.2,
+          "ground_truth": 0,
+          "abs_error": 0.2,
+          "rel_error_pct": 20.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 2.2,
+          "ground_truth": 2.0,
+          "abs_error": 0.2,
+          "rel_error_pct": 10.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 5.0,
+          "ground_truth": 5.5,
+          "abs_error": 0.5,
+          "rel_error_pct": 9.1
+        },
+        "cholesterol_milligrams": {
+          "predicted": 380.0,
+          "ground_truth": 378,
+          "abs_error": 2.0,
+          "rel_error_pct": 0.5
+        },
+        "sodium_milligrams": {
+          "predicted": 200.0,
+          "ground_truth": 170,
+          "abs_error": 30.0,
+          "rel_error_pct": 17.6
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 1.2,
+          "ground_truth": 1.0,
+          "abs_error": 0.2,
+          "rel_error_pct": 20.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 1.2,
+          "ground_truth": 0.5,
+          "abs_error": 0.7,
+          "rel_error_pct": 70.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 13.6,
+          "ground_truth": 13.0,
+          "abs_error": 0.6,
+          "rel_error_pct": 4.6
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "clif-bar-chocolate-chip",
+      "query": "CLIF BAR Chocolate Chip (68g bar)",
+      "category": "branded",
+      "elapsed_seconds": 7.6,
+      "status": "ok",
+      "predicted_description": "CLIF BAR Chocolate Chip (68g bar)",
+      "errors": {
+        "calories": {
+          "predicted": 250.0,
+          "ground_truth": 250,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_fat_grams": {
+          "predicted": 6.0,
+          "ground_truth": 6.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 1.5,
+          "ground_truth": 1.5,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 1.5,
+          "ground_truth": 1.5,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 2.5,
+          "ground_truth": 2.5,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 150.0,
+          "ground_truth": 150,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 44.0,
+          "ground_truth": 44.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 4.0,
+          "ground_truth": 4.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 17.0,
+          "ground_truth": 17.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 17.0,
+          "ground_truth": 17.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 10.0,
+          "ground_truth": 10.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "mcdonalds-big-mac",
+      "query": "McDonald's Big Mac burger",
+      "category": "restaurant",
+      "elapsed_seconds": 9.7,
+      "status": "ok",
+      "predicted_description": "McDonald's Big Mac burger",
+      "errors": {
+        "calories": {
+          "predicted": 550.0,
+          "ground_truth": 563,
+          "abs_error": 13.0,
+          "rel_error_pct": 2.3
+        },
+        "total_fat_grams": {
+          "predicted": 30.0,
+          "ground_truth": 33.0,
+          "abs_error": 3.0,
+          "rel_error_pct": 9.1
+        },
+        "saturated_fat_grams": {
+          "predicted": 11.0,
+          "ground_truth": 11.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "trans_fat_grams": {
+          "predicted": 1.0,
+          "ground_truth": 1.5,
+          "abs_error": 0.5,
+          "rel_error_pct": 33.3
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 2.0,
+          "ground_truth": 2.5,
+          "abs_error": 0.5,
+          "rel_error_pct": 20.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 4.0,
+          "ground_truth": 14.0,
+          "abs_error": 10.0,
+          "rel_error_pct": 71.4
+        },
+        "cholesterol_milligrams": {
+          "predicted": 85.0,
+          "ground_truth": 80,
+          "abs_error": 5.0,
+          "rel_error_pct": 6.2
+        },
+        "sodium_milligrams": {
+          "predicted": 970.0,
+          "ground_truth": 1040,
+          "abs_error": 70.0,
+          "rel_error_pct": 6.7
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 45.0,
+          "ground_truth": 44.0,
+          "abs_error": 1.0,
+          "rel_error_pct": 2.3
+        },
+        "dietary_fiber_grams": {
+          "predicted": 3.0,
+          "ground_truth": 3.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 9.0,
+          "ground_truth": 9.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 5.0,
+          "ground_truth": 7.0,
+          "abs_error": 2.0,
+          "rel_error_pct": 28.6
+        },
+        "protein_grams": {
+          "predicted": 25.0,
+          "ground_truth": 25.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "greek-yogurt-plain",
+      "query": "1 cup plain non-fat Greek yogurt (227g)",
+      "category": "whole_food",
+      "elapsed_seconds": 7.0,
+      "status": "ok",
+      "predicted_description": "1 cup plain non-fat Greek yogurt",
+      "errors": {
+        "calories": {
+          "predicted": 130.0,
+          "ground_truth": 130,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0.7,
+          "abs_error": 0.7,
+          "rel_error_pct": 70.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0.2,
+          "abs_error": 0.2,
+          "rel_error_pct": 20.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0.1,
+          "abs_error": 0.1,
+          "rel_error_pct": 10.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 10.0,
+          "ground_truth": 7,
+          "abs_error": 3.0,
+          "rel_error_pct": 42.9
+        },
+        "sodium_milligrams": {
+          "predicted": 180.0,
+          "ground_truth": 77,
+          "abs_error": 103.0,
+          "rel_error_pct": 133.8
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 9.0,
+          "ground_truth": 9.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 9.0,
+          "ground_truth": 9.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 23.0,
+          "ground_truth": 22.0,
+          "abs_error": 1.0,
+          "rel_error_pct": 4.5
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "salmon-cooked",
+      "query": "100g cooked Atlantic salmon fillet",
+      "category": "whole_food",
+      "elapsed_seconds": 6.4,
+      "status": "ok",
+      "predicted_description": "100g cooked Atlantic salmon fillet",
+      "errors": {
+        "calories": {
+          "predicted": 208.0,
+          "ground_truth": 206,
+          "abs_error": 2.0,
+          "rel_error_pct": 1.0
+        },
+        "total_fat_grams": {
+          "predicted": 13.4,
+          "ground_truth": 12.4,
+          "abs_error": 1.0,
+          "rel_error_pct": 8.1
+        },
+        "saturated_fat_grams": {
+          "predicted": 2.6,
+          "ground_truth": 2.5,
+          "abs_error": 0.1,
+          "rel_error_pct": 4.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 3.4,
+          "ground_truth": 3.9,
+          "abs_error": 0.5,
+          "rel_error_pct": 12.8
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 4.5,
+          "ground_truth": 4.4,
+          "abs_error": 0.1,
+          "rel_error_pct": 2.3
+        },
+        "cholesterol_milligrams": {
+          "predicted": 55.0,
+          "ground_truth": 63,
+          "abs_error": 8.0,
+          "rel_error_pct": 12.7
+        },
+        "sodium_milligrams": {
+          "predicted": 59.0,
+          "ground_truth": 59,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 20.4,
+          "ground_truth": 22.1,
+          "abs_error": 1.7,
+          "rel_error_pct": 7.7
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "avocado-half",
+      "query": "half a medium avocado (68g)",
+      "category": "whole_food",
+      "elapsed_seconds": 8.4,
+      "status": "ok",
+      "predicted_description": "half a medium avocado (68g)",
+      "errors": {
+        "calories": {
+          "predicted": 109.0,
+          "ground_truth": 114,
+          "abs_error": 5.0,
+          "rel_error_pct": 4.4
+        },
+        "total_fat_grams": {
+          "predicted": 10.0,
+          "ground_truth": 10.5,
+          "abs_error": 0.5,
+          "rel_error_pct": 4.8
+        },
+        "saturated_fat_grams": {
+          "predicted": 1.4,
+          "ground_truth": 1.5,
+          "abs_error": 0.1,
+          "rel_error_pct": 6.7
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 1.2,
+          "ground_truth": 1.3,
+          "abs_error": 0.1,
+          "rel_error_pct": 7.7
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 6.7,
+          "ground_truth": 7.1,
+          "abs_error": 0.4,
+          "rel_error_pct": 5.6
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 5.0,
+          "ground_truth": 5,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 5.8,
+          "ground_truth": 6.0,
+          "abs_error": 0.2,
+          "rel_error_pct": 3.3
+        },
+        "dietary_fiber_grams": {
+          "predicted": 4.6,
+          "ground_truth": 4.6,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 0.5,
+          "ground_truth": 0.4,
+          "abs_error": 0.1,
+          "rel_error_pct": 10.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 1.4,
+          "ground_truth": 1.3,
+          "abs_error": 0.1,
+          "rel_error_pct": 7.7
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "sweet-potato-baked",
+      "query": "1 medium baked sweet potato with skin (150g)",
+      "category": "whole_food",
+      "elapsed_seconds": 4.2,
+      "status": "ok",
+      "predicted_description": "1 medium baked sweet potato with skin (150g)",
+      "errors": {
+        "calories": {
+          "predicted": 129.0,
+          "ground_truth": 129,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_fat_grams": {
+          "predicted": 0.2,
+          "ground_truth": 0.1,
+          "abs_error": 0.1,
+          "rel_error_pct": 10.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 0.1,
+          "ground_truth": 0.0,
+          "abs_error": 0.1,
+          "rel_error_pct": 10.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 0.1,
+          "ground_truth": 0.0,
+          "abs_error": 0.1,
+          "rel_error_pct": 10.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 54.0,
+          "ground_truth": 82,
+          "abs_error": 28.0,
+          "rel_error_pct": 34.1
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 30.0,
+          "ground_truth": 30.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 4.5,
+          "ground_truth": 3.8,
+          "abs_error": 0.7,
+          "rel_error_pct": 18.4
+        },
+        "total_sugars_grams": {
+          "predicted": 9.7,
+          "ground_truth": 9.4,
+          "abs_error": 0.3,
+          "rel_error_pct": 3.2
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 2.4,
+          "ground_truth": 2.9,
+          "abs_error": 0.5,
+          "rel_error_pct": 17.2
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "almonds-1oz",
+      "query": "1 oz (28g) dry roasted almonds",
+      "category": "whole_food",
+      "elapsed_seconds": 6.0,
+      "status": "ok",
+      "predicted_description": "1 oz (28g) dry roasted almonds",
+      "errors": {
+        "calories": {
+          "predicted": 164.0,
+          "ground_truth": 170,
+          "abs_error": 6.0,
+          "rel_error_pct": 3.5
+        },
+        "total_fat_grams": {
+          "predicted": 14.2,
+          "ground_truth": 15.0,
+          "abs_error": 0.8,
+          "rel_error_pct": 5.3
+        },
+        "saturated_fat_grams": {
+          "predicted": 1.1,
+          "ground_truth": 1.1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 3.4,
+          "ground_truth": 3.7,
+          "abs_error": 0.3,
+          "rel_error_pct": 8.1
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 9.0,
+          "ground_truth": 9.6,
+          "abs_error": 0.6,
+          "rel_error_pct": 6.2
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 97,
+          "abs_error": 97.0,
+          "rel_error_pct": 100.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 6.1,
+          "ground_truth": 6.0,
+          "abs_error": 0.1,
+          "rel_error_pct": 1.7
+        },
+        "dietary_fiber_grams": {
+          "predicted": 3.5,
+          "ground_truth": 3.3,
+          "abs_error": 0.2,
+          "rel_error_pct": 6.1
+        },
+        "total_sugars_grams": {
+          "predicted": 1.2,
+          "ground_truth": 1.3,
+          "abs_error": 0.1,
+          "rel_error_pct": 7.7
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 6.0,
+          "ground_truth": 6.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "black-beans-cooked",
+      "query": "1/2 cup cooked black beans (86g)",
+      "category": "whole_food",
+      "elapsed_seconds": 3.8,
+      "status": "ok",
+      "predicted_description": "1/2 cup cooked black beans",
+      "errors": {
+        "calories": {
+          "predicted": 114.0,
+          "ground_truth": 114,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_fat_grams": {
+          "predicted": 0.5,
+          "ground_truth": 0.5,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 0.1,
+          "ground_truth": 0.1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 0.2,
+          "ground_truth": 0.2,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 0.1,
+          "ground_truth": 0.0,
+          "abs_error": 0.1,
+          "rel_error_pct": 10.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 2.0,
+          "ground_truth": 1,
+          "abs_error": 1.0,
+          "rel_error_pct": 100.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 20.0,
+          "ground_truth": 20.4,
+          "abs_error": 0.4,
+          "rel_error_pct": 2.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 7.5,
+          "ground_truth": 7.5,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 0.3,
+          "ground_truth": 0.3,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 7.6,
+          "ground_truth": 7.6,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "cheddar-cheese-1oz",
+      "query": "1 oz (28g) sharp cheddar cheese",
+      "category": "whole_food",
+      "elapsed_seconds": 4.9,
+      "status": "ok",
+      "predicted_description": "1 oz (28g) sharp cheddar cheese",
+      "errors": {
+        "calories": {
+          "predicted": 114.0,
+          "ground_truth": 115,
+          "abs_error": 1.0,
+          "rel_error_pct": 0.9
+        },
+        "total_fat_grams": {
+          "predicted": 9.4,
+          "ground_truth": 9.5,
+          "abs_error": 0.1,
+          "rel_error_pct": 1.1
+        },
+        "saturated_fat_grams": {
+          "predicted": 6.0,
+          "ground_truth": 5.4,
+          "abs_error": 0.6,
+          "rel_error_pct": 11.1
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0.3,
+          "abs_error": 0.3,
+          "rel_error_pct": 30.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 0.3,
+          "ground_truth": 0.3,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 2.5,
+          "ground_truth": 2.7,
+          "abs_error": 0.2,
+          "rel_error_pct": 7.4
+        },
+        "cholesterol_milligrams": {
+          "predicted": 30.0,
+          "ground_truth": 30,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 174.0,
+          "ground_truth": 185,
+          "abs_error": 11.0,
+          "rel_error_pct": 5.9
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 0.4,
+          "ground_truth": 0.4,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0.1,
+          "abs_error": 0.1,
+          "rel_error_pct": 10.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 7.1,
+          "ground_truth": 6.4,
+          "abs_error": 0.7,
+          "rel_error_pct": 10.9
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "peanut-butter-2tbsp",
+      "query": "2 tablespoons peanut butter (32g)",
+      "category": "whole_food",
+      "elapsed_seconds": 6.6,
+      "status": "ok",
+      "predicted_description": "2 tablespoons peanut butter",
+      "errors": {
+        "calories": {
+          "predicted": 188.0,
+          "ground_truth": 190,
+          "abs_error": 2.0,
+          "rel_error_pct": 1.1
+        },
+        "total_fat_grams": {
+          "predicted": 16.1,
+          "ground_truth": 16.0,
+          "abs_error": 0.1,
+          "rel_error_pct": 0.6
+        },
+        "saturated_fat_grams": {
+          "predicted": 3.33,
+          "ground_truth": 3.4,
+          "abs_error": 0.07,
+          "rel_error_pct": 2.1
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 4.63,
+          "ground_truth": 4.5,
+          "abs_error": 0.13,
+          "rel_error_pct": 2.9
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 7.98,
+          "ground_truth": 7.5,
+          "abs_error": 0.48,
+          "rel_error_pct": 6.4
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 136.0,
+          "ground_truth": 136,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 7.14,
+          "ground_truth": 7.0,
+          "abs_error": 0.14,
+          "rel_error_pct": 2.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 2.5,
+          "ground_truth": 1.5,
+          "abs_error": 1.0,
+          "rel_error_pct": 66.7
+        },
+        "total_sugars_grams": {
+          "predicted": 3.2,
+          "ground_truth": 3.4,
+          "abs_error": 0.2,
+          "rel_error_pct": 5.9
+        },
+        "added_sugars_grams": {
+          "predicted": 2.0,
+          "ground_truth": 3.0,
+          "abs_error": 1.0,
+          "rel_error_pct": 33.3
+        },
+        "protein_grams": {
+          "predicted": 7.04,
+          "ground_truth": 7.0,
+          "abs_error": 0.04,
+          "rel_error_pct": 0.6
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "cottage-cheese-half-cup",
+      "query": "1/2 cup low-fat (2%) cottage cheese (113g)",
+      "category": "whole_food",
+      "elapsed_seconds": 7.5,
+      "status": "ok",
+      "predicted_description": "1/2 cup low-fat (2%) cottage cheese",
+      "errors": {
+        "calories": {
+          "predicted": 96.0,
+          "ground_truth": 90,
+          "abs_error": 6.0,
+          "rel_error_pct": 6.7
+        },
+        "total_fat_grams": {
+          "predicted": 2.3,
+          "ground_truth": 2.5,
+          "abs_error": 0.2,
+          "rel_error_pct": 8.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 1.5,
+          "ground_truth": 1.0,
+          "abs_error": 0.5,
+          "rel_error_pct": 50.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 0.1,
+          "ground_truth": 0.1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 0.6,
+          "ground_truth": 0.7,
+          "abs_error": 0.1,
+          "rel_error_pct": 10.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 11.0,
+          "ground_truth": 10,
+          "abs_error": 1.0,
+          "rel_error_pct": 10.0
+        },
+        "sodium_milligrams": {
+          "predicted": 396.0,
+          "ground_truth": 360,
+          "abs_error": 36.0,
+          "rel_error_pct": 10.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 4.0,
+          "ground_truth": 5.0,
+          "abs_error": 1.0,
+          "rel_error_pct": 20.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 4.0,
+          "ground_truth": 4.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 13.0,
+          "ground_truth": 12.5,
+          "abs_error": 0.5,
+          "rel_error_pct": 4.0
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "ground-beef-cooked",
+      "query": "100g cooked 80/20 ground beef (pan-fried, drained)",
+      "category": "whole_food",
+      "elapsed_seconds": 8.2,
+      "status": "ok",
+      "predicted_description": "100g cooked 80/20 ground beef (pan-fried, drained)",
+      "errors": {
+        "calories": {
+          "predicted": 254.0,
+          "ground_truth": 254,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_fat_grams": {
+          "predicted": 19.0,
+          "ground_truth": 17.6,
+          "abs_error": 1.4,
+          "rel_error_pct": 8.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 7.6,
+          "ground_truth": 6.8,
+          "abs_error": 0.8,
+          "rel_error_pct": 11.8
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0.6,
+          "abs_error": 0.6,
+          "rel_error_pct": 60.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 0.8,
+          "ground_truth": 0.6,
+          "abs_error": 0.2,
+          "rel_error_pct": 20.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 8.5,
+          "ground_truth": 7.7,
+          "abs_error": 0.8,
+          "rel_error_pct": 10.4
+        },
+        "cholesterol_milligrams": {
+          "predicted": 75.0,
+          "ground_truth": 88,
+          "abs_error": 13.0,
+          "rel_error_pct": 14.8
+        },
+        "sodium_milligrams": {
+          "predicted": 73.0,
+          "ground_truth": 82,
+          "abs_error": 9.0,
+          "rel_error_pct": 11.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 26.0,
+          "ground_truth": 23.2,
+          "abs_error": 2.8,
+          "rel_error_pct": 12.1
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": false
+      }
+    },
+    {
+      "id": "pasta-cooked",
+      "query": "1 cup cooked spaghetti, no sauce (140g)",
+      "category": "whole_food",
+      "elapsed_seconds": 5.7,
+      "status": "ok",
+      "predicted_description": "1 cup cooked spaghetti, no sauce",
+      "errors": {
+        "calories": {
+          "predicted": 221.0,
+          "ground_truth": 220,
+          "abs_error": 1.0,
+          "rel_error_pct": 0.5
+        },
+        "total_fat_grams": {
+          "predicted": 1.3,
+          "ground_truth": 1.3,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 0.2,
+          "ground_truth": 0.3,
+          "abs_error": 0.1,
+          "rel_error_pct": 10.0
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 0.5,
+          "ground_truth": 0.5,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 0.2,
+          "ground_truth": 0.2,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 1.0,
+          "ground_truth": 1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 43.2,
+          "ground_truth": 43.2,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 2.9,
+          "ground_truth": 2.5,
+          "abs_error": 0.4,
+          "rel_error_pct": 16.0
+        },
+        "total_sugars_grams": {
+          "predicted": 0.5,
+          "ground_truth": 0.6,
+          "abs_error": 0.1,
+          "rel_error_pct": 10.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 8.1,
+          "ground_truth": 8.1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "orange-medium",
+      "query": "1 medium orange (131g), peeled",
+      "category": "whole_food",
+      "elapsed_seconds": 12.7,
+      "status": "error",
+      "error": "HTTP Error 500: Internal Server Error"
+    },
+    {
+      "id": "avocado-toast-simple",
+      "query": "1 slice whole wheat toast with 1/4 avocado and a pinch of salt",
+      "category": "composite_meal",
+      "elapsed_seconds": 14.3,
+      "status": "ok",
+      "predicted_description": "1 slice whole wheat toast with 1/4 avocado and a pinch of salt",
+      "errors": {
+        "calories": {
+          "predicted": 160.0,
+          "ground_truth": 175,
+          "abs_error": 15.0,
+          "rel_error_pct": 8.6
+        },
+        "total_fat_grams": {
+          "predicted": 8.0,
+          "ground_truth": 7.4,
+          "abs_error": 0.6,
+          "rel_error_pct": 8.1
+        },
+        "saturated_fat_grams": {
+          "predicted": 1.0,
+          "ground_truth": 1.3,
+          "abs_error": 0.3,
+          "rel_error_pct": 23.1
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 1.5,
+          "ground_truth": 1.5,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 5.5,
+          "ground_truth": 4.0,
+          "abs_error": 1.5,
+          "rel_error_pct": 37.5
+        },
+        "cholesterol_milligrams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 353.0,
+          "ground_truth": 200,
+          "abs_error": 153.0,
+          "rel_error_pct": 76.5
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 19.0,
+          "ground_truth": 24.0,
+          "abs_error": 5.0,
+          "rel_error_pct": 20.8
+        },
+        "dietary_fiber_grams": {
+          "predicted": 5.0,
+          "ground_truth": 5.2,
+          "abs_error": 0.2,
+          "rel_error_pct": 3.8
+        },
+        "total_sugars_grams": {
+          "predicted": 1.0,
+          "ground_truth": 3.5,
+          "abs_error": 2.5,
+          "rel_error_pct": 71.4
+        },
+        "added_sugars_grams": {
+          "predicted": 1.0,
+          "ground_truth": 0,
+          "abs_error": 1.0,
+          "rel_error_pct": 100.0
+        },
+        "protein_grams": {
+          "predicted": 4.0,
+          "ground_truth": 5.5,
+          "abs_error": 1.5,
+          "rel_error_pct": 27.3
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "chicken-rice-bowl",
+      "query": "grilled chicken rice bowl: 150g cooked white rice, 120g grilled chicken breast, no sauce",
+      "category": "composite_meal",
+      "elapsed_seconds": 18.7,
+      "status": "ok",
+      "predicted_description": "grilled chicken rice bowl: 150g cooked white rice, 120g grilled chicken breast, no sauce",
+      "errors": {
+        "calories": {
+          "predicted": 393.0,
+          "ground_truth": 393,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_fat_grams": {
+          "predicted": 4.8,
+          "ground_truth": 4.6,
+          "abs_error": 0.2,
+          "rel_error_pct": 4.3
+        },
+        "saturated_fat_grams": {
+          "predicted": 1.4,
+          "ground_truth": 1.3,
+          "abs_error": 0.1,
+          "rel_error_pct": 7.7
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 1.1,
+          "ground_truth": 1.1,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 1.5,
+          "ground_truth": 1.6,
+          "abs_error": 0.1,
+          "rel_error_pct": 6.3
+        },
+        "cholesterol_milligrams": {
+          "predicted": 102.0,
+          "ground_truth": 102,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "sodium_milligrams": {
+          "predicted": 90.0,
+          "ground_truth": 90,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 42.0,
+          "ground_truth": 42.3,
+          "abs_error": 0.3,
+          "rel_error_pct": 0.7
+        },
+        "dietary_fiber_grams": {
+          "predicted": 0.6,
+          "ground_truth": 0.6,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 41.3,
+          "ground_truth": 37.9,
+          "abs_error": 3.4,
+          "rel_error_pct": 9.0
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "quest-bar-chocolate-chip-cookie",
+      "query": "Quest Bar Chocolate Chip Cookie Dough (60g)",
+      "category": "branded",
+      "elapsed_seconds": 13.0,
+      "status": "ok",
+      "predicted_description": "Quest Bar Chocolate Chip Cookie Dough (60g)",
+      "errors": {
+        "calories": {
+          "predicted": 200.0,
+          "ground_truth": 190,
+          "abs_error": 10.0,
+          "rel_error_pct": 5.3
+        },
+        "total_fat_grams": {
+          "predicted": 8.0,
+          "ground_truth": 8.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "saturated_fat_grams": {
+          "predicted": 2.5,
+          "ground_truth": 3.0,
+          "abs_error": 0.5,
+          "rel_error_pct": 16.7
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 2.5,
+          "ground_truth": 0.0,
+          "abs_error": 2.5,
+          "rel_error_pct": 250.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 3.0,
+          "ground_truth": 0.0,
+          "abs_error": 3.0,
+          "rel_error_pct": 300.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 5.0,
+          "ground_truth": 10,
+          "abs_error": 5.0,
+          "rel_error_pct": 50.0
+        },
+        "sodium_milligrams": {
+          "predicted": 250.0,
+          "ground_truth": 260,
+          "abs_error": 10.0,
+          "rel_error_pct": 3.8
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 22.0,
+          "ground_truth": 22.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "dietary_fiber_grams": {
+          "predicted": 14.0,
+          "ground_truth": 13.0,
+          "abs_error": 1.0,
+          "rel_error_pct": 7.7
+        },
+        "total_sugars_grams": {
+          "predicted": 1.0,
+          "ground_truth": 1.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 1.0,
+          "abs_error": 1.0,
+          "rel_error_pct": 100.0
+        },
+        "protein_grams": {
+          "predicted": 20.0,
+          "ground_truth": 21.0,
+          "abs_error": 1.0,
+          "rel_error_pct": 4.8
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    },
+    {
+      "id": "starbucks-latte-grande",
+      "query": "Starbucks Grande latte with 2% milk (no syrup, 473ml)",
+      "category": "restaurant",
+      "elapsed_seconds": 21.5,
+      "status": "ok",
+      "predicted_description": "Starbucks Grande latte with 2% milk (no syrup, 473ml)",
+      "errors": {
+        "calories": {
+          "predicted": 205.0,
+          "ground_truth": 190,
+          "abs_error": 15.0,
+          "rel_error_pct": 7.9
+        },
+        "total_fat_grams": {
+          "predicted": 8.0,
+          "ground_truth": 7.0,
+          "abs_error": 1.0,
+          "rel_error_pct": 14.3
+        },
+        "saturated_fat_grams": {
+          "predicted": 4.8,
+          "ground_truth": 4.5,
+          "abs_error": 0.3,
+          "rel_error_pct": 6.7
+        },
+        "trans_fat_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "polyunsaturated_fat_grams": {
+          "predicted": 1.2,
+          "ground_truth": 0.3,
+          "abs_error": 0.9,
+          "rel_error_pct": 90.0
+        },
+        "monounsaturated_fat_grams": {
+          "predicted": 2.0,
+          "ground_truth": 2.0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "cholesterol_milligrams": {
+          "predicted": 33.0,
+          "ground_truth": 25,
+          "abs_error": 8.0,
+          "rel_error_pct": 32.0
+        },
+        "sodium_milligrams": {
+          "predicted": 186.0,
+          "ground_truth": 170,
+          "abs_error": 16.0,
+          "rel_error_pct": 9.4
+        },
+        "total_carbohydrate_grams": {
+          "predicted": 20.5,
+          "ground_truth": 19.0,
+          "abs_error": 1.5,
+          "rel_error_pct": 7.9
+        },
+        "dietary_fiber_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "total_sugars_grams": {
+          "predicted": 20.5,
+          "ground_truth": 18.0,
+          "abs_error": 2.5,
+          "rel_error_pct": 13.9
+        },
+        "added_sugars_grams": {
+          "predicted": 0.0,
+          "ground_truth": 0,
+          "abs_error": 0.0,
+          "rel_error_pct": 0.0
+        },
+        "protein_grams": {
+          "predicted": 14.0,
+          "ground_truth": 13.0,
+          "abs_error": 1.0,
+          "rel_error_pct": 7.7
+        }
+      },
+      "within_tolerance": {
+        "calories": true,
+        "total_fat_grams": true,
+        "total_carbohydrate_grams": true,
+        "protein_grams": true
+      }
+    }
+  ]
+}

--- a/llm-nutrition-api/eval/results/gemini-2.5-flash/2026-05-25.md
+++ b/llm-nutrition-api/eval/results/gemini-2.5-flash/2026-05-25.md
@@ -1,0 +1,76 @@
+# LLM Nutrition Agent Eval Report
+
+**Date:** 2026-05-25  
+**Service:** http://localhost:3031  
+**Cases:** 27 total, 26 successful, 1 errors  
+
+## Macro Accuracy Summary
+
+| Macro | MAE | Median AbsErr | % Within Tolerance |
+|-------|-----|---------------|--------------------|
+| Calories | 10.0 | 1.0 | 96% |
+| Total Fat G | 0.6 | 0.2 | 96% |
+| Protein G | 1.8 | 0.3 | 92% |
+| Total Carbohydrate G | 0.4 | 0.1 | 100% |
+
+## Results by Category
+
+**Branded:** 2 ok, 0 errors
+**Composite Meal:** 3 ok, 0 errors
+**Restaurant:** 2 ok, 0 errors
+**Whole Food:** 19 ok, 1 errors
+
+## Per-Case Results
+
+| ID | Category | Status | Calories (pred/gt) | Protein g (pred/gt) | Carbs g (pred/gt) | Fat g (pred/gt) | Time |
+|----|-----------|---------|--------------------|---------------------|-------------------|-----------------|------|
+| egg-large-raw | whole_food | ✓ | 72/72 | 6.3/6.3 | 0.6/0.4 | 4.8/4.8 | 3.4s |
+| chicken-breast-cooked | whole_food | ✓ | 0/165 | 0.0/31.0 | 0.0/0 | 0.0/3.6 | 9.9s |
+| oatmeal-cooked | whole_food | ✓ | 166/166 | 5.9/5.9 | 28.0/28.1 | 3.6/3.6 | 4.0s |
+| banana-medium | whole_food | ✓ | 105/105 | 1.3/1.3 | 27.0/27.0 | 0.4/0.4 | 5.2s |
+| whole-milk-cup | whole_food | ✓ | 150/149 | 8.0/7.7 | 12.0/11.7 | 8.0/8.0 | 4.8s |
+| white-rice-cooked | whole_food | ✓ | 130/130 | 2.7/2.7 | 28.2/28.2 | 0.3/0.3 | 3.5s |
+| broccoli-raw | whole_food | ✓ | 34/34 | 2.8/2.8 | 6.6/6.6 | 0.4/0.4 | 4.8s |
+| olive-oil-tbsp | whole_food | ✓ | 120/119 | 0.0/0 | 0.0/0 | 14.0/13.5 | 3.8s |
+| scrambled-eggs-2 | composite_meal | ✓ | 184/200 | 13.6/13.0 | 1.2/1.0 | 13.6/15.0 | 16.0s |
+| clif-bar-chocolate-chip | branded | ✓ | 250/250 | 10.0/10.0 | 44.0/44.0 | 6.0/6.0 | 7.6s |
+| mcdonalds-big-mac | restaurant | ✓ | 550/563 | 25.0/25.0 | 45.0/44.0 | 30.0/33.0 | 9.7s |
+| greek-yogurt-plain | whole_food | ✓ | 130/130 | 23.0/22.0 | 9.0/9.0 | 0.0/0.7 | 7.0s |
+| salmon-cooked | whole_food | ✓ | 208/206 | 20.4/22.1 | 0.0/0 | 13.4/12.4 | 6.4s |
+| avocado-half | whole_food | ✓ | 109/114 | 1.4/1.3 | 5.8/6.0 | 10.0/10.5 | 8.4s |
+| sweet-potato-baked | whole_food | ✓ | 129/129 | 2.4/2.9 | 30.0/30.0 | 0.2/0.1 | 4.2s |
+| almonds-1oz | whole_food | ✓ | 164/170 | 6.0/6.0 | 6.1/6.0 | 14.2/15.0 | 6.0s |
+| black-beans-cooked | whole_food | ✓ | 114/114 | 7.6/7.6 | 20.0/20.4 | 0.5/0.5 | 3.8s |
+| cheddar-cheese-1oz | whole_food | ✓ | 114/115 | 7.1/6.4 | 0.4/0.4 | 9.4/9.5 | 4.9s |
+| peanut-butter-2tbsp | whole_food | ✓ | 188/190 | 7.0/7.0 | 7.1/7.0 | 16.1/16.0 | 6.6s |
+| cottage-cheese-half-cup | whole_food | ✓ | 96/90 | 13.0/12.5 | 4.0/5.0 | 2.3/2.5 | 7.5s |
+| ground-beef-cooked | whole_food | ✓ | 254/254 | 26.0/23.2 | 0.0/0 | 19.0/17.6 | 8.2s |
+| pasta-cooked | whole_food | ✓ | 221/220 | 8.1/8.1 | 43.2/43.2 | 1.3/1.3 | 5.7s |
+| orange-medium | whole_food | ✗ HTTP Error 500: Internal Server Error | — | — | — | — | 12.7s |
+| avocado-toast-simple | composite_meal | ✓ | 160/175 | 4.0/5.5 | 19.0/24.0 | 8.0/7.4 | 14.3s |
+| chicken-rice-bowl | composite_meal | ✓ | 393/393 | 41.3/37.9 | 42.0/42.3 | 4.8/4.6 | 18.7s |
+| quest-bar-chocolate-chip-cookie | branded | ✓ | 200/190 | 20.0/21.0 | 22.0/22.0 | 8.0/8.0 | 13.0s |
+| starbucks-latte-grande | restaurant | ✓ | 205/190 | 14.0/13.0 | 20.5/19.0 | 8.0/7.0 | 21.5s |
+
+## Observations
+
+Known systematic patterns to watch for:
+
+- **Raw vs cooked confusion**: The agent may report values for raw food when the query
+  specifies cooked (or vice versa). Chicken breast cooked vs raw differs ~15% in calories
+  due to water loss. Rice cooked vs dry differs ~3x.
+- **Serving size ambiguity**: Queries like '1 cup oatmeal' are ambiguous (raw vs cooked);
+  the agent should prefer the cooked interpretation when not specified.
+- **Branded items**: CLIF Bar and McDonald's items require web search tool calls for accurate
+  values. A high tool-use rate for these cases is expected and desirable.
+- **Fat subtype fields**: Polyunsaturated/monounsaturated fat estimates are the least
+  reliable — these are rarely memorized precisely and web sources often omit them.
+
+## How to Re-run
+
+```bash
+# From the llm-nutrition-api/ directory:
+GEMMA_MODEL_PATH=/path/to/gemma-4-E2B-it-Q5_K_M.gguf cargo run &
+sleep 5  # wait for model to load
+python3 eval/run_evals.py --url http://localhost:3031 --output eval/results/
+```

--- a/llm-nutrition-api/src/agent.rs
+++ b/llm-nutrition-api/src/agent.rs
@@ -12,7 +12,7 @@ use crate::NutritionItem;
 
 const MAX_ROUNDS: usize = 5;
 const MAX_NEW_TOKENS: usize = 1024;
-const OPENROUTER_MAX_RETRIES: u32 = 4;
+const API_MAX_RETRIES: u32 = 4;
 
 const SYSTEM_PROMPT: &str = "\
 You are a nutrition expert. Look up or estimate nutritional values for the food the user describes.
@@ -71,9 +71,10 @@ pub enum BackendConfig {
         backend: Arc<LlamaBackend>,
         model: Arc<LlamaModel>,
     },
-    OpenRouter {
+    Api {
         api_key: String,
         model: String,
+        base_url: String,
         client: reqwest::Client,
     },
 }
@@ -193,17 +194,18 @@ fn extract_json(text: &str) -> Option<&str> {
     Some(&slice[..=end])
 }
 
-fn openrouter_error_message(text: &str) -> String {
+fn api_error_message(text: &str) -> String {
     serde_json::from_str::<serde_json::Value>(text)
         .ok()
         .and_then(|v| v["error"]["message"].as_str().map(String::from))
         .unwrap_or_else(|| text.to_string())
 }
 
-async fn call_openrouter(
+async fn call_api(
     client: &reqwest::Client,
     api_key: &str,
     model: &str,
+    base_url: &str,
     conversation: &[(String, String)],
 ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let messages: Vec<serde_json::Value> = conversation
@@ -222,10 +224,11 @@ async fn call_openrouter(
         "max_tokens": MAX_NEW_TOKENS
     });
 
+    let endpoint = format!("{base_url}/chat/completions");
     let mut attempt = 0u32;
     loop {
         let response = client
-            .post("https://openrouter.ai/api/v1/chat/completions")
+            .post(&endpoint)
             .header("Authorization", format!("Bearer {api_key}"))
             .header("Content-Type", "application/json")
             .json(&body)
@@ -233,10 +236,10 @@ async fn call_openrouter(
             .await?;
 
         if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            if attempt >= OPENROUTER_MAX_RETRIES {
+            if attempt >= API_MAX_RETRIES {
                 let text = response.text().await.unwrap_or_default();
-                let msg = openrouter_error_message(&text);
-                return Err(format!("OpenRouter rate limit exceeded after {attempt} retries: {msg}").into());
+                let msg = api_error_message(&text);
+                return Err(format!("LLM API rate limit exceeded after {attempt} retries: {msg}").into());
             }
             // Respect Retry-After if provided, otherwise exponential backoff (1s, 2s, 4s, 8s).
             let delay_secs = response
@@ -245,7 +248,7 @@ async fn call_openrouter(
                 .and_then(|v| v.to_str().ok())
                 .and_then(|s| s.parse::<u64>().ok())
                 .unwrap_or(1u64 << attempt);
-            log::warn!("OpenRouter 429 on attempt {attempt}, retrying in {delay_secs}s");
+            log::warn!("LLM API 429 on attempt {attempt}, retrying in {delay_secs}s");
             tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
             attempt += 1;
             continue;
@@ -254,14 +257,14 @@ async fn call_openrouter(
         if !response.status().is_success() {
             let status = response.status();
             let text = response.text().await.unwrap_or_default();
-            let msg = openrouter_error_message(&text);
-            return Err(format!("OpenRouter API error {status}: {msg}").into());
+            let msg = api_error_message(&text);
+            return Err(format!("LLM API error {status}: {msg}").into());
         }
 
         let json: serde_json::Value = response.json().await?;
         let content = json["choices"][0]["message"]["content"]
             .as_str()
-            .ok_or("Missing content in OpenRouter response")?
+            .ok_or("Missing content in LLM API response")?
             .trim()
             .to_string();
 
@@ -353,10 +356,11 @@ async fn run_agent_local(
     Err("Max agent rounds exceeded without a nutrition answer".into())
 }
 
-async fn run_agent_openrouter(
+async fn run_agent_api(
     client: &reqwest::Client,
     api_key: &str,
     model: &str,
+    base_url: &str,
     description: String,
 ) -> Result<NutritionItem, Box<dyn std::error::Error + Send + Sync>> {
     let mut conversation: Vec<(String, String)> = vec![
@@ -367,7 +371,7 @@ async fn run_agent_openrouter(
     for round in 0..MAX_ROUNDS {
         log::debug!("Agent round {round}");
 
-        let output = call_openrouter(client, api_key, model, &conversation).await?;
+        let output = call_api(client, api_key, model, base_url, &conversation).await?;
         log::debug!("Model output: {output}");
 
         let json_str = extract_json(&output).unwrap_or(&output);
@@ -411,7 +415,7 @@ async fn run_agent_openrouter(
             "Output ONLY the JSON nutrition object. No markdown, no explanation, just the JSON object with all 14 fields.".to_string(),
         ));
 
-        let final_json = call_openrouter(client, api_key, model, &final_conv).await?;
+        let final_json = call_api(client, api_key, model, base_url, &final_conv).await?;
         log::debug!("Final JSON: {final_json}");
 
         let json_str = extract_json(&final_json).unwrap_or(&final_json);
@@ -430,8 +434,8 @@ pub async fn run_agent(
         BackendConfig::Local { backend, model } => {
             run_agent_local(Arc::clone(backend), Arc::clone(model), description).await
         }
-        BackendConfig::OpenRouter { api_key, model, client } => {
-            run_agent_openrouter(client, api_key, model, description).await
+        BackendConfig::Api { api_key, model, base_url, client } => {
+            run_agent_api(client, api_key, model, base_url, description).await
         }
     }
 }

--- a/llm-nutrition-api/src/agent.rs
+++ b/llm-nutrition-api/src/agent.rs
@@ -11,8 +11,9 @@ use serde::Deserialize;
 use crate::NutritionItem;
 
 const MAX_ROUNDS: usize = 5;
-const MAX_NEW_TOKENS: usize = 1024;
-const API_MAX_RETRIES: u32 = 4;
+const MAX_NEW_TOKENS: usize = 1024;       // used for local llama.cpp inference
+const API_MAX_NEW_TOKENS: usize = 8192;   // higher budget for API models with thinking tokens
+const API_MAX_RETRIES: u32 = 8;
 
 const SYSTEM_PROMPT: &str = "\
 You are a nutrition expert. Look up or estimate nutritional values for the food the user describes.
@@ -221,7 +222,7 @@ async fn call_api(
         "model": model,
         "messages": messages,
         "temperature": 0.1,
-        "max_tokens": MAX_NEW_TOKENS
+        "max_tokens": API_MAX_NEW_TOKENS
     });
 
     let endpoint = format!("{base_url}/chat/completions");
@@ -241,13 +242,27 @@ async fn call_api(
                 let msg = api_error_message(&text);
                 return Err(format!("LLM API rate limit exceeded after {attempt} retries: {msg}").into());
             }
-            // Respect Retry-After if provided, otherwise exponential backoff (1s, 2s, 4s, 8s).
-            let delay_secs = response
+            // Prefer Retry-After header, then retryDelay in JSON body, then exponential backoff.
+            let header_secs = response
                 .headers()
                 .get("retry-after")
                 .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.parse::<u64>().ok())
-                .unwrap_or(1u64 << attempt);
+                .and_then(|s| s.parse::<u64>().ok());
+            let text = response.text().await.unwrap_or_default();
+            let body_secs = serde_json::from_str::<serde_json::Value>(&text)
+                .ok()
+                .and_then(|v| {
+                    // Google returns e.g. "retryDelay": "38s" nested under details[].retryDelay
+                    v["error"]["details"]
+                        .as_array()?
+                        .iter()
+                        .find_map(|d| d["retryDelay"].as_str())
+                        .and_then(|s| s.trim_end_matches('s').parse::<u64>().ok())
+                });
+            let delay_secs = header_secs
+                .or(body_secs)
+                .unwrap_or(1u64 << attempt)
+                .max(1);
             log::warn!("LLM API 429 on attempt {attempt}, retrying in {delay_secs}s");
             tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
             attempt += 1;

--- a/llm-nutrition-api/src/main.rs
+++ b/llm-nutrition-api/src/main.rs
@@ -51,9 +51,9 @@ pub struct AppState {
 #[derive(Parser)]
 #[command(about = "LLM-powered nutrition lookup API")]
 struct Args {
-    /// Backend to use: 'local' (llama.cpp + GEMMA_MODEL_PATH) or 'openrouter'
-    /// (OPENROUTER_API_KEY). When omitted, defaults to openrouter if
-    /// OPENROUTER_API_KEY is set, then local if GEMMA_MODEL_PATH is set.
+    /// Backend to use: 'local' (llama.cpp + GEMMA_MODEL_PATH) or 'api'
+    /// (LLM_API_KEY). When omitted, defaults to api if LLM_API_KEY is set,
+    /// then local if GEMMA_MODEL_PATH is set.
     #[arg(long, value_enum)]
     mode: Option<CliMode>,
 }
@@ -61,7 +61,7 @@ struct Args {
 #[derive(Clone, clap::ValueEnum)]
 enum CliMode {
     Local,
-    Openrouter,
+    Api,
 }
 
 fn load_local_model(path: String) -> Arc<agent::BackendConfig> {
@@ -77,24 +77,32 @@ fn load_local_model(path: String) -> Arc<agent::BackendConfig> {
     })
 }
 
-const DEFAULT_OPENROUTER_MODEL: &str = "google/gemma-4-31b-it:free";
+const DEFAULT_LLM_MODEL: &str = "gemini-2.0-flash";
+const DEFAULT_LLM_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta/openai";
 
 fn build_config(mode: Option<CliMode>) -> Arc<agent::BackendConfig> {
-    let openrouter_key = std::env::var("OPENROUTER_API_KEY").ok();
-    let openrouter_model = std::env::var("OPENROUTER_MODEL")
-        .unwrap_or_else(|_| DEFAULT_OPENROUTER_MODEL.to_string());
+    let llm_key = std::env::var("LLM_API_KEY")
+        .or_else(|_| std::env::var("OPENROUTER_API_KEY"))
+        .ok();
+    let llm_model = std::env::var("LLM_MODEL")
+        .or_else(|_| std::env::var("OPENROUTER_MODEL"))
+        .unwrap_or_else(|_| DEFAULT_LLM_MODEL.to_string());
+    let llm_base_url = std::env::var("LLM_BASE_URL")
+        .or_else(|_| std::env::var("OPENROUTER_BASE_URL"))
+        .unwrap_or_else(|_| DEFAULT_LLM_BASE_URL.to_string());
     let model_path = std::env::var("GEMMA_MODEL_PATH").ok();
 
     match mode {
-        Some(CliMode::Openrouter) => {
-            let key = openrouter_key.unwrap_or_else(|| {
-                eprintln!("--mode openrouter requires OPENROUTER_API_KEY to be set");
+        Some(CliMode::Api) => {
+            let key = llm_key.unwrap_or_else(|| {
+                eprintln!("--mode api requires LLM_API_KEY to be set");
                 std::process::exit(1);
             });
-            info!("Using OpenRouter backend ({openrouter_model})");
-            Arc::new(agent::BackendConfig::OpenRouter {
+            info!("Using LLM API backend ({llm_model} at {llm_base_url})");
+            Arc::new(agent::BackendConfig::Api {
                 api_key: key,
-                model: openrouter_model,
+                model: llm_model,
+                base_url: llm_base_url,
                 client: reqwest::Client::new(),
             })
         }
@@ -106,11 +114,12 @@ fn build_config(mode: Option<CliMode>) -> Arc<agent::BackendConfig> {
             load_local_model(path)
         }
         None => {
-            if let Some(key) = openrouter_key {
-                info!("Auto-selected OpenRouter backend ({openrouter_model})");
-                Arc::new(agent::BackendConfig::OpenRouter {
+            if let Some(key) = llm_key {
+                info!("Auto-selected LLM API backend ({llm_model} at {llm_base_url})");
+                Arc::new(agent::BackendConfig::Api {
                     api_key: key,
-                    model: openrouter_model,
+                    model: llm_model,
+                    base_url: llm_base_url,
                     client: reqwest::Client::new(),
                 })
             } else if let Some(path) = model_path {
@@ -119,10 +128,11 @@ fn build_config(mode: Option<CliMode>) -> Arc<agent::BackendConfig> {
             } else {
                 eprintln!(
                     "No backend configured. Either:\n  \
-                     - Set OPENROUTER_API_KEY to use OpenRouter (default: {DEFAULT_OPENROUTER_MODEL})\n  \
+                     - Set LLM_API_KEY to use an OpenAI-compatible API (default model: {DEFAULT_LLM_MODEL})\n  \
                      - Set GEMMA_MODEL_PATH to use the local Gemma model\n  \
-                     - Pass --mode local|openrouter to force a specific backend\n  \
-                     - Set OPENROUTER_MODEL to override the OpenRouter model"
+                     - Pass --mode local|api to force a specific backend\n  \
+                     - Set LLM_MODEL to override the model name\n  \
+                     - Set LLM_BASE_URL to override the API endpoint (default: {DEFAULT_LLM_BASE_URL})"
                 );
                 std::process::exit(1);
             }

--- a/nutrition-fact-labeller/src/main.rs
+++ b/nutrition-fact-labeller/src/main.rs
@@ -14,7 +14,7 @@ use oar_ocr::core::config::onnx::{OrtSessionConfig, OrtExecutionProvider, OrtGra
 use serde_derive::{Deserialize, Serialize};
 use nutrition_fact_labeller::{ParsedNutritionFacts, VlmBackend};
 use nutrition_fact_labeller::vlm::llava::LlavaBackend;
-use nutrition_fact_labeller::vlm::openrouter::{OpenRouterBackend, DEFAULT_MODEL};
+use nutrition_fact_labeller::vlm::openrouter::{LlmApiBackend, DEFAULT_MODEL};
 mod spellcheck;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -116,17 +116,20 @@ async fn main() {
         }
     };
 
-    let or_backend: Option<Arc<OpenRouterBackend>> = {
-        let api_key = std::env::var("OPENROUTER_API_KEY").ok();
+    let api_backend: Option<Arc<LlmApiBackend>> = {
+        let api_key = std::env::var("LLM_API_KEY")
+            .or_else(|_| std::env::var("OPENROUTER_API_KEY"))
+            .ok();
         match api_key {
             Some(key) => {
-                let model = std::env::var("OPENROUTER_MODEL")
+                let model = std::env::var("LLM_MODEL")
+                    .or_else(|_| std::env::var("OPENROUTER_MODEL"))
                     .unwrap_or_else(|_| DEFAULT_MODEL.to_string());
-                info!("OpenRouter VLM backend enabled with model {model}");
-                Some(Arc::new(OpenRouterBackend::new(key, model)))
+                info!("LLM API VLM backend enabled with model {model}");
+                Some(Arc::new(LlmApiBackend::new(key, model)))
             }
             None => {
-                info!("OpenRouter disabled (set OPENROUTER_API_KEY to enable)");
+                info!("LLM API disabled (set LLM_API_KEY to enable)");
                 None
             }
         }
@@ -136,15 +139,15 @@ async fn main() {
         let vlm = vlm.clone();
         warp::any().map(move || vlm.clone())
     };
-    let or_filter = {
-        let or_backend = or_backend.clone();
-        warp::any().map(move || or_backend.clone())
+    let api_filter = {
+        let api_backend = api_backend.clone();
+        warp::any().map(move || api_backend.clone())
     };
 
     let upload = vlm_filter
-        .and(or_filter)
+        .and(api_filter)
         .and(warp::multipart::form().max_length(50 * 1024 * 1024))
-        .and_then(|vlm: Option<Arc<LlavaBackend>>, or_backend: Option<Arc<OpenRouterBackend>>, form: FormData| async move {
+        .and_then(|vlm: Option<Arc<LlavaBackend>>, api_backend: Option<Arc<LlmApiBackend>>, form: FormData| async move {
             // Drain all multipart parts into memory before dispatching.
             let parts: Vec<(String, Vec<u8>)> = form
                 .and_then(|mut part| async move {
@@ -171,11 +174,11 @@ async fn main() {
             let image_bytes = image_bytes.ok_or_else(|| warp::reject::reject())?;
 
             let facts: ParsedNutritionFacts = if backend == "vlm" {
-                // Prefer OpenRouter if configured, fall back to local llama.cpp.
-                if let Some(or) = or_backend {
-                    or.infer(&image_bytes)
+                // Prefer API backend if configured, fall back to local llama.cpp.
+                if let Some(api) = api_backend {
+                    api.infer(&image_bytes)
                         .await
-                        .map_err(|e| { eprintln!("OpenRouter VLM failed: {e}"); warp::reject::reject() })?
+                        .map_err(|e| { eprintln!("LLM API VLM failed: {e}"); warp::reject::reject() })?
                 } else if let Some(vlm_backend) = vlm {
                     tokio::task::spawn_blocking(move || -> anyhow::Result<ParsedNutritionFacts> {
                         // VLM infer() takes a path, so write to a temp file.

--- a/nutrition-fact-labeller/src/vlm/openrouter.rs
+++ b/nutrition-fact-labeller/src/vlm/openrouter.rs
@@ -5,7 +5,7 @@ use crate::ParsedNutritionFacts;
 use super::{extract_json, NUTRITION_PROMPT};
 
 const MAX_TOKENS: u32 = 512;
-const MAX_RETRIES: u32 = 4;
+const MAX_RETRIES: u32 = 8;
 
 pub const DEFAULT_MODEL: &str = "gemini-2.0-flash";
 
@@ -83,12 +83,22 @@ impl LlmApiBackend {
                         "LLM API rate limit exceeded after {attempt} retries: {text}"
                     ));
                 }
-                let delay_secs = response
+                let header_secs = response
                     .headers()
                     .get("retry-after")
                     .and_then(|v| v.to_str().ok())
-                    .and_then(|s| s.parse::<u64>().ok())
-                    .unwrap_or(1u64 << attempt);
+                    .and_then(|s| s.parse::<u64>().ok());
+                let text = response.text().await.unwrap_or_default();
+                let body_secs = serde_json::from_str::<serde_json::Value>(&text)
+                    .ok()
+                    .and_then(|v| {
+                        v["error"]["details"]
+                            .as_array()?
+                            .iter()
+                            .find_map(|d| d["retryDelay"].as_str())
+                            .and_then(|s| s.trim_end_matches('s').parse::<u64>().ok())
+                    });
+                let delay_secs = header_secs.or(body_secs).unwrap_or(1u64 << attempt).max(1);
                 log::warn!("LLM API 429, retrying in {delay_secs}s");
                 tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
                 attempt += 1;

--- a/nutrition-fact-labeller/src/vlm/openrouter.rs
+++ b/nutrition-fact-labeller/src/vlm/openrouter.rs
@@ -7,20 +7,21 @@ use super::{extract_json, NUTRITION_PROMPT};
 const MAX_TOKENS: u32 = 512;
 const MAX_RETRIES: u32 = 4;
 
-pub const DEFAULT_MODEL: &str = "google/gemma-4-31b-it:free";
+pub const DEFAULT_MODEL: &str = "gemini-2.0-flash";
 
-const DEFAULT_BASE_URL: &str = "https://openrouter.ai";
+const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta/openai";
 
-pub struct OpenRouterBackend {
+pub struct LlmApiBackend {
     pub api_key: String,
     pub model: String,
     pub base_url: String,
     pub client: reqwest::Client,
 }
 
-impl OpenRouterBackend {
+impl LlmApiBackend {
     pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Self {
-        let base_url = std::env::var("OPENROUTER_BASE_URL")
+        let base_url = std::env::var("LLM_BASE_URL")
+            .or_else(|_| std::env::var("OPENROUTER_BASE_URL"))
             .unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
         Self::with_base_url(api_key, model, base_url)
     }
@@ -63,7 +64,7 @@ impl OpenRouterBackend {
             "max_tokens": MAX_TOKENS
         });
 
-        let endpoint = format!("{}/api/v1/chat/completions", self.base_url);
+        let endpoint = format!("{}/chat/completions", self.base_url);
         let mut attempt = 0u32;
         loop {
             let response = self.client
@@ -73,13 +74,13 @@ impl OpenRouterBackend {
                 .json(&body)
                 .send()
                 .await
-                .context("Failed to send OpenRouter request")?;
+                .context("Failed to send LLM API request")?;
 
             if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
                 if attempt >= MAX_RETRIES {
                     let text = response.text().await.unwrap_or_default();
                     return Err(anyhow::anyhow!(
-                        "OpenRouter rate limit exceeded after {attempt} retries: {text}"
+                        "LLM API rate limit exceeded after {attempt} retries: {text}"
                     ));
                 }
                 let delay_secs = response
@@ -88,7 +89,7 @@ impl OpenRouterBackend {
                     .and_then(|v| v.to_str().ok())
                     .and_then(|s| s.parse::<u64>().ok())
                     .unwrap_or(1u64 << attempt);
-                log::warn!("OpenRouter 429, retrying in {delay_secs}s");
+                log::warn!("LLM API 429, retrying in {delay_secs}s");
                 tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
                 attempt += 1;
                 continue;
@@ -97,16 +98,16 @@ impl OpenRouterBackend {
             if !response.status().is_success() {
                 let status = response.status();
                 let text = response.text().await.unwrap_or_default();
-                return Err(anyhow::anyhow!("OpenRouter API error {status}: {text}"));
+                return Err(anyhow::anyhow!("LLM API error {status}: {text}"));
             }
 
             let json: serde_json::Value = response
                 .json()
                 .await
-                .context("Failed to parse OpenRouter response")?;
+                .context("Failed to parse LLM API response")?;
             let output = json["choices"][0]["message"]["content"]
                 .as_str()
-                .ok_or_else(|| anyhow::anyhow!("Missing content in OpenRouter response"))?
+                .ok_or_else(|| anyhow::anyhow!("Missing content in LLM API response"))?
                 .trim()
                 .to_string();
 
@@ -234,7 +235,7 @@ mod tests {
                 .unwrap_or_else(|_| panic!("missing image: {filename}"));
 
             let (base_url, mock_rx) = spawn_mock(openrouter_response(&expected)).await;
-            let backend = OpenRouterBackend::with_base_url("test-key", "test-model", &base_url);
+            let backend = LlmApiBackend::with_base_url("test-key", "test-model", &base_url);
             let actual = backend.infer(&img_bytes).await
                 .unwrap_or_else(|e| panic!("infer failed for {filename}: {e}"));
 


### PR DESCRIPTION
Replace OpenRouter (free-tier Gemma) with direct Google AI calls via
their OpenAI-compatible endpoint (generativelanguage.googleapis.com).
Default model is now gemini-2.0-flash.

- Env vars renamed: OPENROUTER_API_KEY → LLM_API_KEY,
  OPENROUTER_MODEL → LLM_MODEL, OPENROUTER_BASE_URL → LLM_BASE_URL
- Old OPENROUTER_* vars are still read as fallbacks for back-compat
- OpenRouterBackend renamed to LlmApiBackend; BackendConfig::OpenRouter
  → BackendConfig::Api (with base_url field)
- Endpoint path fixed: /api/v1/chat/completions → /chat/completions
  to match Google AI's OpenAI-compat URL structure

https://claude.ai/code/session_01TVpCxPRnw8r5SRvTqTvDjF