### PR TITLE
Round entry macros to integers in diary list

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -7,3 +7,4 @@ src-gleam/build
 src-gleam/tags
 .lustre/
 .worktrees/
+.vitest-attachments/

--- a/web/src/DiaryList.test.tsx
+++ b/web/src/DiaryList.test.tsx
@@ -625,8 +625,8 @@ describe("DiaryList", () => {
 
     await waitFor(() => {
       // Recipe has total_servings: 1. Per-serving protein = (1.3 + 5) / 1 = 6.3g.
-      // Diary entry logs 2 servings: 2 * 6.3 = 12.6g protein.
-      expect(screen.getByText(/12.6g protein/)).toBeTruthy();
+      // Diary entry logs 2 servings: 2 * 6.3 = 12.6g protein, rounded to 13g.
+      expect(screen.getByText(/13g protein/)).toBeTruthy();
     });
   });
 

--- a/web/src/DiaryList.tsx
+++ b/web/src/DiaryList.tsx
@@ -213,9 +213,9 @@ const DiaryList: Component = () => {
                     {(entry: () => DiaryEntry, i: number) => (
                       <li class="mb-4">
                         <p class="font-semibold">
-                          {entry().calories} kcal,{" "}
-                          {entryTotalMacro("protein_grams", entry())}g protein,{" "}
-                          {entryTotalMacro("dietary_fiber_grams", entry())}g
+                          {Math.round(entry().calories)} kcal,{" "}
+                          {Math.round(entryTotalMacro("protein_grams", entry()))}g protein,{" "}
+                          {Math.round(entryTotalMacro("dietary_fiber_grams", entry()))}g
                           fiber
                         </p>
                         <p>

--- a/web/src/DiaryList.tsx
+++ b/web/src/DiaryList.tsx
@@ -214,9 +214,14 @@ const DiaryList: Component = () => {
                       <li class="mb-4">
                         <p class="font-semibold">
                           {Math.round(entry().calories)} kcal,{" "}
-                          {Math.round(entryTotalMacro("protein_grams", entry()))}g protein,{" "}
-                          {Math.round(entryTotalMacro("dietary_fiber_grams", entry()))}g
-                          fiber
+                          {Math.round(
+                            entryTotalMacro("protein_grams", entry()),
+                          )}
+                          g protein,{" "}
+                          {Math.round(
+                            entryTotalMacro("dietary_fiber_grams", entry()),
+                          )}
+                          g fiber
                         </p>
                         <p>
                           <a

--- a/web/src/acceptance.test.tsx
+++ b/web/src/acceptance.test.tsx
@@ -105,8 +105,8 @@ describe("Browser Acceptance Tests", () => {
       { timeout: 5000 },
     );
 
-    // Banana: 1 serving * 3.1g fiber
-    expect(screen.getByText(/3\.1g fiber/i)).toBeTruthy();
+    // Banana: 1 serving * 3.1g fiber, rounded to 3g
+    expect(screen.getByText(/3g fiber/i)).toBeTruthy();
   });
 
   it("should complete Add Item flow - create new item and log it", async () => {


### PR DESCRIPTION
Calories, protein, and fiber values in the per-entry summary line were
displayed as raw decimals. Wrap each with Math.round() to match the
integer display already applied in the CircleProgress components.

https://claude.ai/code/session_01F6DuqCWR7K86rZx6CWgMLh