### PR TITLE
docs(ios): add implementation plans covering the iOS app PRD

### DIFF
--- a/ios/plans/README.md
+++ b/ios/plans/README.md
@@ -15,8 +15,8 @@ out-of-band setup.
 | [`backend-nutrition-targets.md`](backend-nutrition-targets.md) | §9 (the only backend change for v1) | Phase 0/1 |
 | [`auth0-testflight-setup.md`](auth0-testflight-setup.md) | §16 + §17 (manual Auth0 tenant + TestFlight runbook) | Phase 0 → first run |
 | [`phase-1-core-logging.md`](phase-1-core-logging.md) | §4 (diary list, entries, items, recipes, search, suggestions, targets, profile), §7.1 calcs, §8 contract | Phase 1 (v1) |
-| [`ci.md`](ci.md) | §12 CI + decision #14 | Phase 0, maintained throughout |
-| [`testing.md`](testing.md) | §12 mandatory unit tests + §6.5 auth tests | Phase 0/1 |
+| [`ci.md`](ci.md) | §12 CI + decision #14 | **Phase 0 (first PR)**, maintained throughout |
+| [`testing.md`](testing.md) | §12 mandatory unit tests + §6.5 auth tests | **Phase 0 (set up first)**, grown throughout |
 | [`phase-2-insights.md`](phase-2-insights.md) | §11 Phase 2 (Trends / Swift Charts) | Phase 2 |
 | [`phase-3-native-capture.md`](phase-3-native-capture.md) | §11 Phase 3 (label scan + LLM autofill) | Phase 3 |
 | [`phase-4-data-portability.md`](phase-4-data-portability.md) | §11 Phase 4 (CSV import/export) | Phase 4 |
@@ -36,12 +36,19 @@ out-of-band setup.
 
 ## Suggested execution order
 
-1. `phase-0-foundation.md` (project skeleton, auth, networking, navigation).
-2. `backend-nutrition-targets.md` (apply migration + metadata; unblocks targets).
-3. `auth0-testflight-setup.md` (manual Auth0 setup — required before login works).
-4. `phase-1-core-logging.md` (the v1 feature surface) + `testing.md` + `ci.md`.
-5. Ship v1 to TestFlight (PRD §15 Definition of Done).
-6. Phases 2–5 as additive follow-ups, each independent.
+1. **Testing + CI infra first** — `phase-0-foundation.md` §1.2 with
+   [`testing.md`](testing.md) §0 and [`ci.md`](ci.md): create the test target and
+   the `test-ios` GitHub Actions job against a trivial walking-skeleton test. The
+   **first `ios/` PR must show CI green** so automated testing is the standard from
+   commit one, and everything after is built **test-first**.
+2. Rest of `phase-0-foundation.md` (auth, networking, models, navigation) — each
+   unit added with its tests in the same change, CI staying green.
+3. `backend-nutrition-targets.md` (apply migration + metadata; unblocks targets).
+4. `auth0-testflight-setup.md` (manual Auth0 setup — required before login works).
+5. `phase-1-core-logging.md` (the v1 feature surface), every screen's logic
+   landing with its `testing.md` coverage.
+6. Ship v1 to TestFlight (PRD §15 Definition of Done).
+7. Phases 2–5 as additive follow-ups, each independent.
 
 ## Source-of-truth references in this repo
 

--- a/ios/plans/README.md
+++ b/ios/plans/README.md
@@ -7,6 +7,10 @@ the existing web app, tests, and a definition of done. Together they cover the
 **entirety** of the PRD — every section, decision, phase, and the manual
 out-of-band setup.
 
+> **Tracking progress:** [`STATUS.md`](STATUS.md) is the living checklist of what's
+> done across all phases (plus the §15 Definition of Done and §17 manual setup).
+> Update it in the same PR that completes an item.
+
 ## How the plans map to the PRD
 
 | Plan | PRD coverage | Ships in |

--- a/ios/plans/README.md
+++ b/ios/plans/README.md
@@ -1,0 +1,56 @@
+# Food Diary iOS — Implementation Plans
+
+These plans turn the PRD (`specs/2026-06-20-ios-app.md`) into concrete,
+sequenced engineering work. Each plan is self-contained: objective,
+prerequisites, file-by-file breakdown, key implementation details ported from
+the existing web app, tests, and a definition of done. Together they cover the
+**entirety** of the PRD — every section, decision, phase, and the manual
+out-of-band setup.
+
+## How the plans map to the PRD
+
+| Plan | PRD coverage | Ships in |
+|---|---|---|
+| [`phase-0-foundation.md`](phase-0-foundation.md) | §2, §3, §6 (architecture, OIDC client, GraphQL client, DI, navigation, login gate), §7 models, §10 config, §13 deps | Phase 0 |
+| [`backend-nutrition-targets.md`](backend-nutrition-targets.md) | §9 (the only backend change for v1) | Phase 0/1 |
+| [`auth0-testflight-setup.md`](auth0-testflight-setup.md) | §16 + §17 (manual Auth0 tenant + TestFlight runbook) | Phase 0 → first run |
+| [`phase-1-core-logging.md`](phase-1-core-logging.md) | §4 (diary list, entries, items, recipes, search, suggestions, targets, profile), §7.1 calcs, §8 contract | Phase 1 (v1) |
+| [`ci.md`](ci.md) | §12 CI + decision #14 | Phase 0, maintained throughout |
+| [`testing.md`](testing.md) | §12 mandatory unit tests + §6.5 auth tests | Phase 0/1 |
+| [`phase-2-insights.md`](phase-2-insights.md) | §11 Phase 2 (Trends / Swift Charts) | Phase 2 |
+| [`phase-3-native-capture.md`](phase-3-native-capture.md) | §11 Phase 3 (label scan + LLM autofill) | Phase 3 |
+| [`phase-4-data-portability.md`](phase-4-data-portability.md) | §11 Phase 4 (CSV import/export) | Phase 4 |
+| [`phase-5-platform-polish.md`](phase-5-platform-polish.md) | §11 Phase 5 (iPad, cache, widgets, HealthKit, App Store) | Phase 5+ |
+
+## Locked decisions (from PRD §2) that constrain every plan
+
+- iOS **18+**, Swift + SwiftUI, **MVVM + `@Observable`**, `@MainActor` view models.
+- GraphQL over **URLSession + Codable**, hand-written query strings mirroring
+  `web/src/Api.ts` — **no codegen, zero third-party dependencies** in v1.
+- Auth is a **hand-rolled OIDC** Authorization Code + PKCE client on
+  `AuthenticationServices` + `CryptoKit` + `Security` (no Auth0 SDK).
+- **Online-only** (no local store in v1). Nutrition targets are the one piece of
+  state moved server-side (§9).
+- Single `NavigationStack` rooted at the diary list; toolbar menu for add/profile.
+- iPhone-only, portrait-first. Backend base URL switchable via build config.
+
+## Suggested execution order
+
+1. `phase-0-foundation.md` (project skeleton, auth, networking, navigation).
+2. `backend-nutrition-targets.md` (apply migration + metadata; unblocks targets).
+3. `auth0-testflight-setup.md` (manual Auth0 setup — required before login works).
+4. `phase-1-core-logging.md` (the v1 feature surface) + `testing.md` + `ci.md`.
+5. Ship v1 to TestFlight (PRD §15 Definition of Done).
+6. Phases 2–5 as additive follow-ups, each independent.
+
+## Source-of-truth references in this repo
+
+- Web API operations to mirror: `web/src/Api.ts`.
+- Macro/stat calculations to port exactly: `web/src/DiaryList.tsx`,
+  `web/src/WeeklyStatsCalculations.ts`, `web/src/CircleProgress.tsx`.
+- Suggestion sourcing/merge logic: `web/src/NewDiaryEntryForm.tsx`.
+- Backend schema/permissions to extend: `graphql-engine/migrations/default/*`,
+  `graphql-engine/metadata/databases/default/tables/*`.
+- CI conventions: `.github/workflows/ci-cd.yml` (paths-filter + per-package jobs).
+</content>
+</invoke>

--- a/ios/plans/STATUS.md
+++ b/ios/plans/STATUS.md
@@ -1,0 +1,114 @@
+# Food Diary iOS — Implementation Status
+
+Living status of the work described in the PRD (`specs/2026-06-20-ios-app.md`) and
+the plans in this folder. **Update this file as part of the same PR that completes
+an item** (check the box, add the PR # and date). It is the single source of truth
+for "what's done"; the plans describe *how*, this tracks *whether*.
+
+**Legend:** ☐ not started · ◐ in progress · ☑ done
+
+**Last updated:** _not yet started_
+
+---
+
+## Phase status overview
+
+| Phase / plan | Status | PR(s) | Notes |
+|---|---|---|---|
+| Phase 0 — Foundation | ☐ | — | test target + CI first (§1.2) |
+| ↳ Testing + CI infra (first PR) | ☐ | — | walking-skeleton test, `test-ios` green |
+| Backend — nutrition targets (§9) | ☐ | — | migration + metadata applied |
+| Auth0 + TestFlight manual setup (§16/§17) | ☐ | — | out-of-band; see checklist below |
+| Phase 1 — Core logging (v1) | ☐ | — | diary/entries/items/recipes/targets/profile |
+| Phase 2 — Insights (Trends) | ☐ | — | deferred from v1 |
+| Phase 3 — Native capture (scan + LLM) | ☐ | — | deferred from v1 |
+| Phase 4 — Data portability (CSV) | ☐ | — | deferred from v1 |
+| Phase 5+ — Platform polish | ☐ | — | iPad, cache, widgets, HealthKit, App Store |
+
+---
+
+## Phase 0 — Foundation ([plan](phase-0-foundation.md))
+
+- [ ] Xcode project under `ios/` builds for an iOS 18 simulator from clean checkout
+- [ ] `FoodDiaryTests` target + walking-skeleton test (§1.2)
+- [ ] `test-ios` CI job green on the first `ios/` PR (§1.2, [ci.md](ci.md))
+- [ ] Config (`.xcconfig` + `Info.plist` `CFBundleURLTypes`) wired (§1.1)
+- [ ] Models decode (golden JSON, snake_case, item/recipe XOR) (§2)
+- [ ] PKCE + OIDCClient + Keychain + TokenStore (refresh coalescing) (§3)
+- [ ] GraphQLClient + APIError mapping (§4)
+- [ ] DI container + login gate + NavigationStack route enum (§5/§6)
+- [ ] Phase 0 unit tests pass in CI (PKCE vectors, exp decode, coalescing, errors)
+
+## Backend — Nutrition targets ([plan](backend-nutrition-targets.md))
+
+- [ ] Migration up/down applies cleanly
+- [ ] Table tracked + `user` role permissions + `on_conflict` upsert work (RLS-scoped)
+- [ ] `GetNutritionTargets` / `SetNutritionTargets` verified against a real JWT
+
+## Auth0 + TestFlight manual setup ([runbook](auth0-testflight-setup.md), PRD §17)
+
+> ⚠️ Out-of-band — none of this is created by building the project.
+
+- [ ] Auth0: Native application created in the existing tenant (§16.1)
+- [ ] Auth0: Allowed Callback + Logout URLs set to the custom scheme (§16.2)
+- [ ] Auth0: Refresh Token Rotation + Authorization Code & Refresh Token grants (§16.3)
+- [ ] Auth0: Hasura API audience allows offline access + identifier matches (§16.4)
+- [ ] App config: Domain/Client ID/Scheme in `.xcconfig`; audience+redirect in Swift; `Info.plist` scheme (§16.5)
+- [ ] Verify: login round-trip returns a Hasura-claims JWT (§16.6)
+- [ ] Backend: `nutrition_target` migration + metadata applied (§9)
+- [ ] TestFlight: App Store Connect record, signing/provisioning, first upload
+
+## Phase 1 — Core logging / v1 ([plan](phase-1-core-logging.md))
+
+- [ ] GraphQL operations mirrored from `web/src/Api.ts` (§1) — each with golden decode test
+- [ ] Repositories (protocol-backed) for diary/items/recipes/search/suggestions/targets
+- [ ] `MacroCalculations` + `WeeklyStats` + `DateHelpers` ported and unit-tested (§3)
+- [ ] Diary list: rings, grouping, 7-day/4-week headers, paging, empty state (§4)
+- [ ] Add/edit/delete entry with search + 3 suggestion sources (§5); delete optimistic + rollback
+- [ ] Nutrition items: create/view/edit (§6)
+- [ ] Recipes: create/view/edit (delete-then-insert items) (§7)
+- [ ] Nutrition targets: view/edit, server-stored, drive rings (§8)
+- [ ] Profile: user info, targets link, debug env switcher, logout (§9)
+- [ ] DesignSystem: `MacroRing` (exact color rules), `DateBadge`, `Theme` (§10)
+- [ ] Error/session handling: 401/403 → re-login; per-screen loading/error (§11)
+
+## Phase 2 — Insights / Trends ([plan](phase-2-insights.md))
+
+- [ ] `GetWeeklyTrends` + `TrendsRepository` (+ decode test)
+- [ ] Trends screen (Swift Charts): calories/protein/added-sugar series
+- [ ] "View Trends" link un-hidden from the diary header
+
+## Phase 3 — Native capture ([plan](phase-3-native-capture.md))
+
+- [ ] Precondition: sidecar ingress accepts the Bearer JWT (§0)
+- [ ] `/llm/lookup` autofill on item form (+ decode/error/mapping tests)
+- [ ] `/labeller/upload` camera scan autofill (+ permissions)
+
+## Phase 4 — Data portability ([plan](phase-4-data-portability.md))
+
+- [ ] Export/import GraphQL ops added
+- [ ] CSV serialize/parse ported, round-trip vs. web fixtures (tested)
+- [ ] Export via share sheet/Files; import via Files picker with preview
+
+## Phase 5+ — Platform polish ([plan](phase-5-platform-polish.md))
+
+- [ ] iPad adaptive layouts
+- [ ] SwiftData read cache
+- [ ] Widgets / Shortcuts
+- [ ] HealthKit
+- [ ] App Store readiness (privacy labels, account deletion, public release)
+
+---
+
+## v1 Definition of Done (PRD §15)
+
+v1 ships when **all** of these hold:
+
+- [ ] Signed TestFlight build installs and runs on iOS 18+ iPhone
+- [ ] Login/logout via Auth0; session survives relaunch
+- [ ] Diary list: correct per-day rings + 7-day/4-week headers, matching web for same data
+- [ ] Add/edit/delete entries (item & recipe), create/edit items, create/edit recipes, with search + suggestions
+- [ ] Nutrition targets persist on the server and drive the rings
+- [ ] Mandatory unit tests pass in CI; CI builds the app on `ios/` PRs
+- [ ] Auth0 tenant + backend manual setup complete (§16/§17 checklist above)
+</content>

--- a/ios/plans/auth0-testflight-setup.md
+++ b/ios/plans/auth0-testflight-setup.md
@@ -1,0 +1,130 @@
+# Auth0 Tenant + TestFlight — Manual Setup Runbook
+
+**PRD coverage:** §10, §16 (Auth0 tenant config), §17 (reminder checklist), §14
+(the top risk: callback URL not yet configured), §15 (DoD includes this).
+
+> ⚠️ **None of this is created by building the Xcode project.** It is out-of-band
+> setup done by hand in the Auth0 dashboard, Hasura, and App Store Connect. Login
+> will not work and TestFlight cannot ship until it's complete. Schedule it as the
+> final gate before first run.
+
+This runbook is the actionable expansion of PRD §16/§17. Work top to bottom.
+
+---
+
+## A. Auth0 — Native application (§16.1)
+
+The iOS app reuses the **existing tenant** that backs the web app but needs its
+**own Native application** (the web app is a SPA; Native is a separate secret-less
+public client using PKCE).
+
+1. Auth0 Dashboard → **Applications → Applications → Create Application**.
+2. Name `Food Diary iOS`, Type **Native**, Create.
+3. From **Settings**, copy **Domain** and **Client ID** → these become
+   `AUTH0_DOMAIN` / `AUTH0_CLIENT_ID` in `ios/Config/Shared.xcconfig`. A Native
+   app has **no client secret** (correct — public client).
+
+## B. Callback / logout URLs (§16.2)
+
+Custom scheme tied to the bundle id `com.bspaulding.fooddiary`. Callback URL
+format: `{SCHEME}://{AUTH0_DOMAIN}/ios/{BUNDLE_ID}/callback`.
+
+In the Native app's **Settings**:
+- **Allowed Callback URLs:**
+  `com.bspaulding.fooddiary://<AUTH0_DOMAIN>/ios/com.bspaulding.fooddiary/callback`
+- **Allowed Logout URLs:** the same value (used by `/v2/logout` return).
+- Save.
+
+> The redirect URI contains `://`, so it is **assembled in Swift**, not in
+> xcconfig (PRD §16.5). The Swift value must match this Auth0 entry **exactly**.
+
+## C. Refresh tokens with rotation (§16.3)
+
+In the Native app's settings:
+- **Refresh Token Rotation:** enable **Rotation**.
+- **Refresh Token Expiration:** enable **Absolute** (optionally **Inactivity**).
+- **Settings → Advanced → Grant Types:** ensure **Authorization Code** and
+  **Refresh Token** are checked.
+- The app requests `offline_access` in code (§6.5) so a refresh token is issued.
+
+## D. API (audience) authorizes the Native app (§16.4)
+
+The access token must be a **JWT for the Hasura API**
+(`https://direct-satyr-14.hasura.app/v1/graphql`):
+- Auth0 → **Applications → APIs → [Hasura API] → Settings:** ensure **Allow
+  Offline Access** is enabled.
+- No per-app authorization toggle is needed for Native against a standard API,
+  but verify the audience identifier **exactly** matches the constant the app
+  sends (`OIDCClient.audience`).
+
+## E. App config lands the values (§16.5)
+
+`ios/Config/Shared.xcconfig` (only values **without** `://`):
+```
+AUTH0_DOMAIN    = <tenant>.us.auth0.com
+AUTH0_CLIENT_ID = <native app client id>
+AUTH0_SCHEME    = com.bspaulding.fooddiary
+```
+In Swift (constants, because they contain `://`):
+- audience: `"https://direct-satyr-14.hasura.app/v1/graphql"`
+- redirect: `"\(scheme)://\(domain)/ios/\(bundleId)/callback"`
+
+Register the scheme in `Info.plist` → `CFBundleURLTypes` so the OS routes the
+callback back to the app.
+
+## F. Backend — apply the targets migration (§9)
+
+See [`backend-nutrition-targets.md`](backend-nutrition-targets.md). Then:
+```bash
+cd graphql-engine
+hasura migrate apply
+hasura metadata apply
+```
+
+## G. Verify the login round-trip (§16.6)
+
+- Run the app, tap **Log In** → Auth0 universal-login appears in the in-app
+  browser sheet → returns to the app after login.
+- Decode the returned `access_token` (jwt.io or a debug log of claims) and confirm
+  it contains `https://hasura.io/jwt/claims` with `x-hasura-user-id`. **If the
+  token is opaque (not a JWT), the `audience` param is missing/wrong** (§6.5).
+- Confirm a GraphQL query returns the signed-in user's data.
+
+## H. TestFlight (§17 last item)
+
+- App Store Connect: create the app record (bundle id
+  `com.bspaulding.fooddiary`).
+- Signing/provisioning: distribution cert + App Store provisioning profile (or
+  Xcode automatic signing with the team).
+- Archive a **Release** build (production ingress) and upload the first build to
+  TestFlight; add yourself as an internal tester.
+
+---
+
+## §17 Checklist (mirrors the PRD — tick before first run / TestFlight)
+
+- [ ] Auth0: create the **Native** application in the existing tenant (A).
+- [ ] Auth0: set Allowed **Callback** and **Logout** URLs to the custom scheme (B).
+- [ ] Auth0: enable **Refresh Token Rotation** + Authorization Code & Refresh
+      Token grants (C).
+- [ ] Auth0: confirm the Hasura **API audience** allows offline access and the
+      identifier matches (D).
+- [ ] App config: Domain / Client ID / Scheme in `.xcconfig`; audience + redirect
+      in Swift; `CFBundleURLTypes` registered in `Info.plist` (E).
+- [ ] Verify: login round-trip returns a Hasura-claims JWT (G).
+- [ ] Backend: apply the `nutrition_target` migration + metadata (F / §9).
+- [ ] TestFlight: App Store Connect record, signing/provisioning, first upload (H).
+
+---
+
+## Common failure modes (from PRD §6.5 / §14)
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Token is opaque, Hasura rejects it | `audience` param missing/wrong | Send exact audience constant (§6.5 #1, D) |
+| No refresh token returned | `offline_access` not requested or API offline-access off | Add scope (§6.5 #2) + enable on API (C/D) |
+| Surprise logouts after a while | Rotated refresh token not persisted | Persist new refresh token on every refresh (§6.5 #3) |
+| Random logouts under load | Concurrent refresh race | `TokenStore` actor coalescing (§6.5 #4) |
+| Tokens lost / Keychain errors at launch | Wrong accessibility class | `kSecAttrAccessibleAfterFirstUnlock` (§6.5 #5) |
+| Callback never returns to app | Scheme/redirect mismatch | Auth0 callback === Swift redirect === `Info.plist` scheme (B/E) |
+</content>

--- a/ios/plans/backend-nutrition-targets.md
+++ b/ios/plans/backend-nutrition-targets.md
@@ -1,0 +1,202 @@
+# Backend Change — Nutrition Targets on Server (§9)
+
+**PRD coverage:** §4.6, §8 (targets get/set), §9. This is the **only** backend
+change required for iOS v1 (decision #8). It is purely additive: the web app keeps
+using `localStorage` until it opts in (the web migration is a separate,
+non-blocking follow-up).
+
+**Goal:** a per-user `food_diary.nutrition_target` table, tracked in Hasura with
+`user` role permissions and upsert support, so iOS (and later web) can read/write
+targets that drive the diary-list rings.
+
+---
+
+## 1. Migration
+
+Follow the repo's Hasura migration convention
+(`graphql-engine/migrations/default/<timestamp>_<name>/{up,down}.sql`). Create a
+new timestamped folder, e.g. `<ts>_create_nutrition_target/`.
+
+`up.sql`:
+```sql
+CREATE TABLE food_diary.nutrition_target (
+    user_id text NOT NULL PRIMARY KEY,
+    calories numeric NOT NULL DEFAULT 2000,
+    calories_max numeric NOT NULL DEFAULT 2400,
+    protein_grams numeric NOT NULL DEFAULT 130,
+    dietary_fiber_grams numeric NOT NULL DEFAULT 25,
+    added_sugars_grams numeric NOT NULL DEFAULT 25,
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Reuse the existing updated_at trigger function from the init migration.
+CREATE TRIGGER set_food_diary_nutrition_target_updated_at
+    BEFORE UPDATE ON food_diary.nutrition_target
+    FOR EACH ROW
+    EXECUTE FUNCTION food_diary.set_current_timestamp_updated_at();
+```
+
+`down.sql`:
+```sql
+DROP TABLE food_diary.nutrition_target;
+```
+
+> `set_current_timestamp_updated_at()` already exists (defined in
+> `1664466824542_init/up.sql`), so the trigger reuses it — no new function needed.
+
+Defaults match the web app's `DEFAULT_TARGETS` (`web/src/NutritionTargets.tsx`)
+and PRD §4.6: 2000 / 2400 / 130 / 25 / 25.
+
+---
+
+## 2. Hasura metadata
+
+### 2.1 Track the table
+Add `food_diary_nutrition_target.yaml` under
+`graphql-engine/metadata/databases/default/tables/` and register it in
+`tables.yaml` (alphabetical, with the other `"!include ..."` entries).
+
+### 2.2 `user` role permissions (§9)
+Model them on `food_diary_nutrition_item.yaml` (same `user_id`-scoped pattern):
+
+```yaml
+table:
+  name: nutrition_target
+  schema: food_diary
+insert_permissions:
+  - role: user
+    permission:
+      check:
+        user_id:
+          _eq: X-Hasura-User-Id
+      set:
+        user_id: x-hasura-User-Id
+      columns:
+        - calories
+        - calories_max
+        - protein_grams
+        - dietary_fiber_grams
+        - added_sugars_grams
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - user_id
+        - calories
+        - calories_max
+        - protein_grams
+        - dietary_fiber_grams
+        - added_sugars_grams
+        - updated_at
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
+update_permissions:
+  - role: user
+    permission:
+      columns:
+        - calories
+        - calories_max
+        - protein_grams
+        - dietary_fiber_grams
+        - added_sugars_grams
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
+      check: null
+      set:
+        user_id: x-hasura-User-Id
+delete_permissions:
+  - role: user
+    permission:
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
+```
+
+> The `user_id` is server-derived from the JWT (`set: user_id: x-hasura-User-Id`);
+> the iOS app **never** sends it (PRD §3).
+
+### 2.3 Enable upsert (`on_conflict`)
+For the save path the app uses `insert ... on_conflict` keyed on the `user_id`
+primary key (PRD §9). Hasura exposes `on_conflict` automatically when the table
+has a unique/primary key **and** the `user` role has both insert and update
+permissions on the conflicting columns — which §2.2 grants. Confirm
+`insert_food_diary_nutrition_target_one(object:, on_conflict: {constraint:
+nutrition_target_pkey, update_columns: [...]})` appears in the schema after apply.
+
+---
+
+## 3. GraphQL operations the iOS app will use (§8)
+
+These are implemented in the iOS `Api.swift` (Phase 1) but specified here so the
+metadata above is verified to support them:
+
+**Get targets** (returns 0 or 1 row):
+```graphql
+query GetNutritionTargets {
+  food_diary_nutrition_target {
+    calories
+    calories_max
+    protein_grams
+    dietary_fiber_grams
+    added_sugars_grams
+  }
+}
+```
+
+**Upsert targets** (save path):
+```graphql
+mutation SetNutritionTargets($target: food_diary_nutrition_target_insert_input!) {
+  insert_food_diary_nutrition_target_one(
+    object: $target
+    on_conflict: {
+      constraint: nutrition_target_pkey
+      update_columns: [calories, calories_max, protein_grams, dietary_fiber_grams, added_sugars_grams]
+    }
+  ) {
+    user_id
+  }
+}
+```
+
+App behavior (PRD §9): on launch, run `GetNutritionTargets`; if no row, use
+`NutritionTargets.default` and create on first save via the upsert. Cache in
+memory for the session (online-only).
+
+---
+
+## 4. Apply & verify
+
+```bash
+cd graphql-engine
+hasura migrate apply
+hasura metadata apply
+```
+(Use the project's existing Hasura CLI config/endpoint/admin-secret, per the
+graphql-engine README.)
+
+**Verify:**
+- `GetNutritionTargets` returns `[]` for a fresh user.
+- `SetNutritionTargets` inserts a row; a second call with the same user updates
+  it (no duplicate, `updated_at` advances).
+- A second user cannot see the first user's row (RLS filter).
+
+---
+
+## 5. Follow-up (not blocking iOS — PRD §9)
+
+Migrate the **web** app from `localStorage` (`web/src/NutritionTargets.tsx`) to
+this table for true cross-platform sync. Track as a separate task in `web/`. Until
+then, web and iOS targets diverge — acceptable per the PRD.
+
+---
+
+## 6. Definition of Done
+
+- Migration up/down apply cleanly; `down` fully reverts.
+- Table tracked; `user` role insert/select/update/delete + `on_conflict` work and
+  are RLS-scoped by `user_id`.
+- The two operations in §3 succeed end-to-end against a real JWT.
+- Included in the §17 manual-setup checklist as "apply migration + metadata".
+</content>

--- a/ios/plans/ci.md
+++ b/ios/plans/ci.md
@@ -6,6 +6,11 @@
 **Goal:** build the app and run the unit-test bundle on PRs that touch `ios/`,
 using `xcodebuild` on a macOS runner with an iOS 18 simulator.
 
+> **This is part of the very first scaffolding PR** (Phase 0 §1.2), not a later
+> add-on. The `test-ios` job must run green against the walking-skeleton test
+> bundle before any feature/auth code exists, so automated testing is enforced
+> from commit one and stays green throughout development.
+
 ---
 
 ## 1. Integrate with the existing workflow

--- a/ios/plans/ci.md
+++ b/ios/plans/ci.md
@@ -1,0 +1,91 @@
+# CI — GitHub Actions for iOS
+
+**PRD coverage:** §12 (CI), decision #14. Matches the repo's existing
+`.github/workflows/ci-cd.yml` conventions (paths-filter + per-package jobs).
+
+**Goal:** build the app and run the unit-test bundle on PRs that touch `ios/`,
+using `xcodebuild` on a macOS runner with an iOS 18 simulator.
+
+---
+
+## 1. Integrate with the existing workflow
+
+The repo uses a single `ci-cd.yml` with a `changes` job (`dorny/paths-filter`)
+gating per-package jobs (`test-web`, etc.). Two options:
+
+- **Preferred:** add an `ios` filter to the existing `changes` job and a new
+  `test-ios` job gated on it. Keeps one workflow, matches the established pattern.
+- **Alternative:** a standalone `.github/workflows/ios.yml` with its own
+  `paths: ["ios/**"]` trigger. Simpler isolation; pick this if the macOS runner
+  cost/queueing should be fully decoupled.
+
+This plan specifies the **preferred** integration.
+
+### 1.1 Add the filter (in the `changes` job)
+```yaml
+outputs:
+  ios: ${{ steps.filter.outputs.ios }}
+# ...
+filters: |
+  ios:
+    - "ios/**"
+```
+
+### 1.2 Add the job
+```yaml
+test-ios:
+  needs: changes
+  if: |
+    (github.event_name == 'pull_request' || github.ref == 'refs/heads/main') &&
+    needs.changes.outputs.ios == 'true'
+  runs-on: macos-15        # provides Xcode 16 / iOS 18 SDK
+  defaults:
+    run:
+      working-directory: ios
+  env:
+    TZ: America/Los_Angeles   # date-sensitive tests (matches web)
+  steps:
+    - uses: actions/checkout@v4
+    - name: Select Xcode 16
+      run: sudo xcode-select -s /Applications/Xcode_16.app
+    - name: Show available simulators
+      run: xcrun simctl list devices available
+    - name: Build & test
+      run: |
+        xcodebuild test \
+          -project FoodDiary.xcodeproj \
+          -scheme FoodDiary \
+          -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.0' \
+          -resultBundlePath TestResults.xcresult \
+          CODE_SIGNING_ALLOWED=NO | xcbeautify
+    - name: Upload results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ios-test-results
+        path: ios/TestResults.xcresult
+```
+
+Notes:
+- `CODE_SIGNING_ALLOWED=NO` — CI builds for the simulator, no provisioning needed.
+- Pin a concrete simulator name/OS available on the runner image; adjust if the
+  hosted image's default device differs (the "Show available simulators" step
+  helps diagnose).
+- `xcbeautify` is optional log formatting; drop it if avoiding the install.
+- The Auth0 config values needed at runtime are **not** needed to build/test —
+  unit tests don't perform real network auth (they use fakes, `testing.md`).
+
+---
+
+## 2. What CI guards
+
+- Compiles the app target (catches concurrency/`Sendable` violations from §6.3).
+- Runs the mandatory unit tests (`testing.md` §1): calculations, decoding, error
+  mapping, auth crypto + refresh coalescing.
+
+## 3. Definition of Done
+
+- A PR touching `ios/` triggers `test-ios`; PRs not touching `ios/` skip it.
+- Job builds and runs the test bundle green on the macOS runner with
+  `TZ=America/Los_Angeles`.
+</content>

--- a/ios/plans/phase-0-foundation.md
+++ b/ios/plans/phase-0-foundation.md
@@ -10,6 +10,13 @@ exchanges the code for a Hasura-claims JWT, persists/refreshes the session, and
 shows an empty authenticated shell rooted at a `NavigationStack`. No feature
 screens yet — those are Phase 1.
 
+> **Testing + CI come first (§1.2).** Before any auth, networking, or model code
+> is written, stand up the test target and the GitHub Actions pipeline against a
+> trivial walking-skeleton test. This sets the standard for the whole project:
+> **every subsequent unit of work lands with tests and a green CI run.** Do
+> [`testing.md`](testing.md) §0 and [`ci.md`](ci.md) as the first scaffolding
+> step — see §1.2 below — then build the rest of Phase 0 test-first.
+
 > **Blocker:** login cannot be exercised end-to-end until the manual Auth0 setup
 > in [`auth0-testflight-setup.md`](auth0-testflight-setup.md) is done. Build the
 > code first; verify against the live tenant once that runbook is complete.
@@ -74,6 +81,37 @@ Surface the three keys into `Info.plist` (`AUTH0_DOMAIN = $(AUTH0_DOMAIN)`, etc.
 and read them via a small typed `AppConfig` loader. Register the custom scheme in
 `Info.plist` under `CFBundleURLTypes` with `CFBundleURLSchemes =
 [com.bspaulding.fooddiary]` so the OS can route the callback (PRD §16.5).
+
+### 1.2 Walking skeleton — testing + CI **before** any feature code
+
+> **Do this immediately after the project compiles and before §2–§6.** The point
+> is to make "tests + green CI" the default state from commit one, so every
+> later unit (models, auth, networking) is added test-first against a pipeline
+> that already runs. This operationalizes decisions #13 (test scope) and #14 (CI).
+
+1. **Create the `FoodDiaryTests` target** (Swift Testing, Xcode 16+), wired to the
+   `FoodDiary` scheme so `xcodebuild test` runs it.
+2. **Add one trivial test** (a "walking skeleton", e.g. assert `AppConfig` reads
+   the bundled `AUTH0_SCHEME`) so the bundle is non-empty and proves the harness
+   and simulator destination work end to end.
+3. **Stand up CI now** per [`ci.md`](ci.md): the `test-ios` job
+   (macOS runner, iOS 18 simulator, `TZ=America/Los_Angeles`,
+   `CODE_SIGNING_ALLOWED=NO`) gated on the `ios/**` paths filter. The **first PR
+   that adds the Xcode project must show `test-ios` green** — that is the gate
+   that establishes the standard.
+4. **Establish the testing conventions** (full matrix in [`testing.md`](testing.md)):
+   - Swift Testing (`@Test`/`#expect`), no XCUITest in v1 (minimal scope, #13).
+   - Pure logic (`Util/`, decoding, auth crypto) is unit-tested; UI is not.
+   - Repositories and the token endpoint are **protocol-backed** so tests inject
+     fakes — define the protocols before the concrete impls.
+   - Date-sensitive tests assume `TZ=America/Los_Angeles` (matches `web/`).
+5. **Build the rest of Phase 0 test-first:** each of §2 (models decode), §3 (PKCE,
+   exp, refresh coalescing), §4 (error mapping) ships with its tests in the same
+   change, and CI stays green throughout.
+
+After this step the repo has: a compiling app, a runnable (if tiny) test bundle,
+and a CI job that runs it on every `ios/**` PR. Everything below is added on top
+of that foundation.
 
 ---
 
@@ -249,7 +287,9 @@ every Phase 1 feature, so finalize the enum cases here.
 
 ## 8. Tests delivered in Phase 0
 
-(Full matrix in [`testing.md`](testing.md); Phase 0 owns the auth + error pieces.)
+(The test target + CI were stood up first in §1.2; these are the specific tests
+added test-first alongside §2–§4. Full matrix in [`testing.md`](testing.md);
+Phase 0 owns the auth + error pieces.)
 - PKCE challenge vs. RFC 7636 known vectors.
 - Authorize-URL construction (all params present + encoded).
 - JWT `exp` decoding (base64url payload).
@@ -261,6 +301,8 @@ every Phase 1 feature, so finalize the enum cases here.
 
 ## 9. Definition of Done (Phase 0)
 
+- **The first `ios/` PR lands with the test target + `test-ios` CI job green**
+  (§1.2) — the testing/CI standard is in place before feature code.
 - `ios/FoodDiary.xcodeproj` builds for an iOS 18 simulator from a clean checkout.
 - App launches to a login screen; tapping Log In opens `ASWebAuthenticationSession`.
 - After the manual Auth0 setup (`auth0-testflight-setup.md`), a full login

--- a/ios/plans/phase-0-foundation.md
+++ b/ios/plans/phase-0-foundation.md
@@ -1,0 +1,274 @@
+# Phase 0 — Foundation
+
+**PRD coverage:** §2 (architecture decisions), §3 (system context), §6 (layers,
+concurrency, navigation, custom OIDC), §7 (Swift data models), §10 (config/
+environments), §11 (Phase 0 row), §13 (zero deps).
+
+**Goal:** A buildable, testable Xcode project with a working login gate. After
+this phase, the app launches, presents Auth0 login via `ASWebAuthenticationSession`,
+exchanges the code for a Hasura-claims JWT, persists/refreshes the session, and
+shows an empty authenticated shell rooted at a `NavigationStack`. No feature
+screens yet — those are Phase 1.
+
+> **Blocker:** login cannot be exercised end-to-end until the manual Auth0 setup
+> in [`auth0-testflight-setup.md`](auth0-testflight-setup.md) is done. Build the
+> code first; verify against the live tenant once that runbook is complete.
+
+---
+
+## 0. Prerequisites
+
+- Xcode 16+ (Swift Testing, iOS 18 SDK).
+- The bundle id decision: `com.bspaulding.fooddiary` (per PRD §16.2), scheme
+  `com.bspaulding.fooddiary`.
+- Read access to the live Auth0 tenant values (domain, native client id) — only
+  needed at verification time, not to write the code.
+
+---
+
+## 1. Project creation & structure
+
+Create the project committed under `ios/` (decision #9, #10):
+
+```
+ios/
+  FoodDiary.xcodeproj
+  FoodDiary/            # app target
+  FoodDiaryTests/       # Swift Testing unit-test target
+  Config/              # .xcconfig files (decision #16)
+  README.md
+```
+
+Build the directory tree exactly as PRD §6.2 specifies (`App/`, `Auth/`,
+`Networking/`, `Models/`, `Repositories/`, `Features/`, `DesignSystem/`, `Util/`).
+Phase 0 fills `App/`, `Auth/`, `Networking/`, `Models/`, and the DI container;
+the `Features/` folders are created empty (or with placeholder views) and filled
+in Phase 1.
+
+**Targets & settings**
+- iOS Deployment Target **18.0**; iPhone only; portrait + portrait-upside-down off.
+- Swift language mode 6 (or 5 with strict concurrency `complete`) so `@MainActor`/
+  `Sendable` boundaries from §6.3 are enforced at compile time.
+- Two build configurations beyond defaults are unnecessary; reuse **Debug** and
+  **Release** and branch behavior on `#if DEBUG` (decision #16, §10):
+  - **Release** → production ingress `https://food-diary.motingo.com`.
+  - **Debug** → defaults to production, with an in-app Developer override
+    (Phase 1 Profile screen) to point Hasura/sidecars at a LAN host.
+
+### 1.1 Config files (§10, §16.5)
+
+`Config/Shared.xcconfig` (committed, no secrets — client id/domain are public):
+
+```
+AUTH0_DOMAIN    = <tenant>.us.auth0.com
+AUTH0_CLIENT_ID = <native app client id>
+AUTH0_SCHEME    = com.bspaulding.fooddiary
+PRODUCT_BUNDLE_IDENTIFIER = com.bspaulding.fooddiary
+```
+
+> ⚠️ **xcconfig treats `//` as a comment** (PRD §16.5). Never put a value
+> containing `://` here. The **audience** and **redirect URI** are assembled in
+> Swift instead (see §3 below).
+
+Surface the three keys into `Info.plist` (`AUTH0_DOMAIN = $(AUTH0_DOMAIN)`, etc.)
+and read them via a small typed `AppConfig` loader. Register the custom scheme in
+`Info.plist` under `CFBundleURLTypes` with `CFBundleURLSchemes =
+[com.bspaulding.fooddiary]` so the OS can route the callback (PRD §16.5).
+
+---
+
+## 2. Models (`Models/`, PRD §7)
+
+Create the Codable models exactly as in PRD §7 — `NutritionItem`, `RecipeItem`,
+`Recipe`, `DiaryEntry`, `NutritionTargets` (with the `.default` static). Notes
+driving the implementation:
+
+- **Decimals:** Postgres `numeric` arrives as JSON numbers → decode as `Double`.
+  IDs are `Int`. (`calories` is `integer` in the DB for `nutrition_item` but the
+  computed `diary_entry.calories`/`recipe.calories` are `numeric`; decode all as
+  `Double` to match the web, which treats everything as `number`.)
+- **Timestamps:** `timestamptz` ISO-8601 with fractional seconds. Decode with a
+  custom `JSONDecoder.dateDecodingStrategy` using an `ISO8601DateFormatter` that
+  has `.withFractionalSeconds` (and a fallback formatter without it, since Hasura
+  may omit fractional seconds). Display in the device local timezone via the
+  `DateHelpers` (Phase 1 / §7).
+- **Key mapping:** default decoder uses `keyDecodingStrategy =
+  .convertFromSnakeCase` (PRD §7 decision). Where a query uses GraphQL field
+  aliases (e.g. `getNutritionItemQuery` aliases to camelCase in `web/src/Api.ts`),
+  the response is already camelCase — keep the decoder consistent by aliasing in
+  the Swift query strings too, OR rely on `.convertFromSnakeCase` and **not**
+  alias. Decision for iOS: **do not alias in queries; request snake_case and let
+  `.convertFromSnakeCase` map.** This keeps one decoding rule everywhere.
+- **XOR:** `DiaryEntry.nutritionItem` and `.recipe` are both optional; the DB
+  `CHECK (has_recipe_xor_item)` guarantees exactly one. Decoding tolerates either.
+
+Put a `Codable` round-trip + golden-JSON decode test stub here; the real golden
+tests live with Phase 1 once query shapes are final (`testing.md`).
+
+---
+
+## 3. Auth — custom OIDC client (`Auth/`, PRD §6.5)
+
+This is the highest-risk area; implement it in small, individually testable units.
+**The five things to get right (§6.5):** always send `audience`; request
+`offline_access`; persist rotated refresh tokens; coalesce concurrent refreshes;
+Keychain accessibility `kSecAttrAccessibleAfterFirstUnlock`.
+
+### 3.1 `PKCE.swift` (CryptoKit)
+- `codeVerifier`: 32 random bytes (`SecRandomCopyBytes`) → base64url (no padding).
+- `codeChallenge = base64url(SHA256(verifier))` via `CryptoKit.SHA256`.
+- `state`: random base64url string.
+- **Unit-test against known RFC 7636 vectors** (§6.5 tests).
+
+### 3.2 `OIDCClient.swift`
+Computed config (assembled in Swift, not xcconfig — §16.5):
+- `audience = "https://direct-satyr-14.hasura.app/v1/graphql"` (constant).
+- `redirectURI = "\(scheme)://\(domain)/ios/\(bundleId)/callback"`.
+
+`login()` flow (§6.5 steps 1–5):
+1. Generate PKCE + `state`.
+2. Build the `/authorize` URL with `response_type=code`, `client_id`,
+   `redirect_uri`, `scope=openid profile email offline_access`, `audience`,
+   `code_challenge`, `code_challenge_method=S256`, `state`. **Unit-test that the
+   URL contains every param, correctly percent-encoded** (§6.5 tests).
+3. Run `ASWebAuthenticationSession` with the custom scheme as
+   `callbackURLScheme`; provide an `ASWebAuthenticationPresentationContextProviding`.
+4. On callback: verify `state`, extract `code`. On user-cancel, surface a
+   distinct `.cancelled` (not an error toast).
+5. POST `/oauth/token` (`grant_type=authorization_code`) with `code`,
+   `code_verifier`, `client_id`, `redirect_uri`. Decode `access_token`,
+   `refresh_token`, `expires_in`.
+
+`refresh()` — POST `/oauth/token` (`grant_type=refresh_token`); **persist the new
+rotated refresh token every time** (§6.5). `logout()` URL builder for
+`/v2/logout` (return to the registered logout URL) to clear the Auth0 cookie.
+
+### 3.3 `Keychain.swift`
+~60-line wrapper over `Security` (`SecItemAdd`/`Copy`/`Update`/`Delete`). Stores
+**only the refresh token**. Accessibility **must** be
+`kSecAttrAccessibleAfterFirstUnlock` (§6.5 item 5).
+
+### 3.4 `TokenStore.swift` (actor)
+- Holds in-memory `accessToken` + `expiry`; reads refresh token from Keychain.
+- `currentToken()` returns a valid access token, refreshing first if expired or
+  within a small skew window (e.g. 60s).
+- **Expiry source:** decode JWT `exp` (split on `.`, base64url-decode the payload,
+  read `exp`) — **no signature check** (§3, §6.5). Fall back to `expires_in`.
+  **Unit-test `exp` decoding.**
+- **Refresh coalescing:** if multiple callers request a token while expired, only
+  **one** `/oauth/token` call runs; others await the same `Task`. Implement with a
+  stored `Task<String, Error>?` guarded by the actor. **Unit-test: N concurrent
+  callers ⇒ exactly 1 token request** (§6.5 tests, the marquee test).
+
+### 3.5 `AuthService.swift` + `AuthState.swift` (`@Observable`)
+- `@Observable @MainActor` facade: `login()`, `logout()`, `currentToken()`
+  (delegates to `TokenStore`), and a published `state: .signedOut | .signedIn(User)`.
+- On launch: if a refresh token exists in Keychain, attempt a silent refresh →
+  `.signedIn`; else `.signedOut`.
+- Expose the decoded `id_token`/userinfo (name/email/picture) for the Profile
+  screen (Phase 1). The `picture`/`name`/`email` come from the `openid profile
+  email` scopes.
+
+---
+
+## 4. Networking (`Networking/`, PRD §6.1, §8)
+
+### 4.1 `APIError.swift`
+```
+enum APIError: Error {
+  case unauthorized              // 401/403 (after refresh failed)
+  case graphQL([GraphQLError])   // non-empty GraphQL errors array
+  case transport(underlying:)    // other non-2xx / URLError
+  case decoding(underlying:)
+}
+```
+Mirror `web/src/Api.ts`: 401/403 → `.unauthorized`; non-empty `errors` →
+`.graphQL`; other non-2xx → `.transport`. **Unit-test the mapping** (§12).
+
+### 4.2 `GraphQLClient.swift` (struct/actor, `Sendable`)
+- One `execute<T: Decodable>(_ operation: GraphQLOperation) async throws -> T`.
+- Builds `POST {GRAPHQL_BASE}/api/v1/graphql`, sets `Authorization: Bearer
+  <token>` from `AuthService.currentToken()`, body `{ query, variables }`.
+- On `.unauthorized`: trigger `AuthService.logout()` → root routes to login
+  (mirrors web `registerLogoutHandler` / `AuthorizationError`, §4.1, §8).
+- Decodes the GraphQL envelope `{ data, errors }`, returns typed `data`.
+- Base URL resolved from `AppEnvironment` (production by default; debug override).
+
+### 4.3 `Api.swift`
+Home for the **query/mutation strings**, mirroring `web/src/Api.ts` 1:1. In
+Phase 0, only include what login-gate smoke-testing needs (none strictly), but
+establish the pattern: each operation is a `static let` query string + a
+`Codable` response struct. Phase 1 fills in all v1 operations (see
+`phase-1-core-logging.md` §"GraphQL operations").
+
+---
+
+## 5. App composition (`App/`, PRD §6.1, §6.4)
+
+### 5.1 `AppEnvironment.swift` — DI container
+- Holds singletons: `AppConfig`, `AuthService`, `GraphQLClient`, and the five
+  repositories (protocol-typed so tests inject doubles — §6.1). Repos are
+  defined now as protocols with concrete impls stubbed; Phase 1 implements them.
+- Exposes the resolved base URL (prod vs. debug override).
+
+### 5.2 `FoodDiaryApp.swift` (`@main`)
+- Creates `AppEnvironment`, injects via `.environment(...)`.
+- Roots `RootView`.
+
+### 5.3 `RootView.swift` — login gate (§6.4)
+- Switches on `AuthService.state`:
+  - `.signedOut` → `LoginView` (a single "Log in" button calling
+    `authService.login()`; shows spinner + error).
+  - `.signedIn` → `NavigationStack` shell with a typed route enum (§6.4):
+    `.itemDetail(id)`, `.itemEdit(id)`, `.recipeDetail(id)`, `.recipeEdit(id)`,
+    `.newEntry`, `.editEntry(id)`, `.newItem`, `.newRecipe`. Define the enum and
+    `.navigationDestination(for:)` switch now; destinations render placeholders
+    until Phase 1.
+- Root content in Phase 0 is a placeholder "Diary" screen; the toolbar menu
+  (Profile/Settings + add actions) is wired in Phase 1.
+
+---
+
+## 6. Navigation contract (§6.4)
+
+Lock the route enum + `NavigationPath` ownership in a small `Router`
+(`@Observable`, held by `RootView`). Forms presented as **sheets** where it reads
+better (quick add); detail/edit pushed on the stack. This contract is consumed by
+every Phase 1 feature, so finalize the enum cases here.
+
+---
+
+## 7. Concurrency rules (§6.3)
+
+- View models `@MainActor @Observable`; repositories/clients `Sendable` value
+  types or actors. `URLSession.data(for:)` for all requests.
+- Screen loads via `.task {}` with cancellation on disappear.
+- Enforce with strict concurrency checking (set in §1).
+
+---
+
+## 8. Tests delivered in Phase 0
+
+(Full matrix in [`testing.md`](testing.md); Phase 0 owns the auth + error pieces.)
+- PKCE challenge vs. RFC 7636 known vectors.
+- Authorize-URL construction (all params present + encoded).
+- JWT `exp` decoding (base64url payload).
+- **Refresh coalescing:** N concurrent `currentToken()` callers ⇒ 1 token request
+  (inject a fake token endpoint that counts calls).
+- `APIError` mapping: 401/403 → `.unauthorized`; GraphQL `errors` → `.graphQL`.
+
+---
+
+## 9. Definition of Done (Phase 0)
+
+- `ios/FoodDiary.xcodeproj` builds for an iOS 18 simulator from a clean checkout.
+- App launches to a login screen; tapping Log In opens `ASWebAuthenticationSession`.
+- After the manual Auth0 setup (`auth0-testflight-setup.md`), a full login
+  round-trip returns a **Hasura-claims JWT** (verify `x-hasura-user-id` per §16.6),
+  the session persists across relaunch (silent refresh), and logout returns to login.
+- A trivial authenticated GraphQL query (e.g. `GetWeeklyStats`) succeeds against
+  the live backend.
+- Phase 0 unit tests pass locally and in CI (`ci.md`).
+- Zero third-party dependencies (decision #13) — only `AuthenticationServices`,
+  `CryptoKit`, `Security`, `Foundation`, `SwiftUI`.
+</content>

--- a/ios/plans/phase-1-core-logging.md
+++ b/ios/plans/phase-1-core-logging.md
@@ -1,0 +1,266 @@
+# Phase 1 (v1) — Core Logging
+
+**PRD coverage:** §4 (all of 4.1–4.7), §7.1 (ported calculations), §8 (GraphQL
+contract), §11 (Phase 1 row), §15 (Definition of Done).
+
+**Goal:** core food-logging **parity** with the web app: diary list with rings
+and weekly averages and paging; add/edit/delete entries with search and
+suggestions; create/view/edit nutrition items; create/view/edit recipes;
+server-stored nutrition targets; profile/logout.
+
+**Depends on:** Phase 0 (auth, networking, navigation, DI, models) and
+[`backend-nutrition-targets.md`](backend-nutrition-targets.md) applied.
+
+---
+
+## 1. GraphQL operations (`Networking/Api.swift`, PRD §8)
+
+Mirror `web/src/Api.ts` exactly. Each operation = a query string + a `Codable`
+response/variables struct. Request **snake_case** fields and let
+`.convertFromSnakeCase` map them (Phase 0 decision — do **not** use the web's
+camelCase aliases). Include a shared `Macros` fragment and `diaryEntryFields` as
+the web does.
+
+**Queries**
+- `GetEntries` — three variants (all / from-date / date-range), `order_by: { day:
+  desc, consumed_at: asc }`, selecting `id, consumed_at, calories, servings,
+  nutrition_item { id, description, calories, ...Macros }, recipe { id, name,
+  calories, total_servings, recipe_items { servings, nutrition_item { ...Macros }}}`.
+  `Macros` = `added_sugars_grams, protein_grams, dietary_fiber_grams`.
+- `GetWeeklyStats` — `current_week` + `past_four_weeks` `_aggregate { sum {
+  calories }}` with `$currentWeekStart, $todayStart, $fourWeeksAgoStart`.
+- `SearchItemsAndRecipes($search)` → `food_diary_search_nutrition_items {id,
+  description}` + `food_diary_search_recipes {id, name}`.
+- `SearchItems($search)` — items only (for recipe-item picking).
+- `GetRecentEntryItems` → `food_diary_diary_entry_recent(order_by:{consumed_at:
+  desc}, limit:5)`.
+- `TopEntriesAroundHour($startHour,$endHour)` →
+  `food_diary_top_entries_around_hour(args:{start_hour,end_hour,n:5})`.
+- `GetTopLoggedItems` → last 100 `food_diary_diary_entry` (client-side
+  most-logged merge, see §4).
+- `GetNutritionItem($id)`, `GetRecipe($id)`, `GetDiaryEntry($id)` — detail/edit.
+- `GetNutritionTargets` (§9 / backend plan).
+
+**Mutations**
+- `CreateNutritionItem($nutritionItem)`, `UpdateItem($id,$attrs)`.
+- `CreateRecipe($input)` (nested `recipe_items: { data: [...] }`),
+  `UpdateRecipe($id,$attrs,$items)` (**delete-then-insert** recipe items, exactly
+  as `web/src/Api.ts updateRecipe` does — one mutation with update + delete +
+  insert).
+- `CreateDiaryEntry($entry)` (item **xor** recipe input), `UpdateDiaryEntry($id,
+  $attrs)` (servings + consumed_at), `DeleteEntry($id)`.
+- `SetNutritionTargets($target)` upsert (§9 / backend plan).
+
+> **snake_case for inputs:** the web hand-rolls `objectToSnakeCaseKeys` for insert/
+> set inputs. In Swift, give the *input* structs `CodingKeys` (or encode with
+> `.convertToSnakeCase`) so `totalFatGrams` → `total_fat_grams`, etc.
+
+Each operation gets a **golden-JSON decode test** (`testing.md`, §12).
+
+---
+
+## 2. Repositories (`Repositories/`, PRD §6.1)
+
+Protocol + concrete impl wrapping `GraphQLClient`, one per domain. Protocols let
+view-model tests inject doubles.
+
+- `DiaryRepository`: `entries(page:)` (computes week window, see §3),
+  `weeklyStats()`, `entry(id:)`, `createEntry(_:)`, `updateEntry(_:)`,
+  `deleteEntry(id:)`.
+- `NutritionItemRepository`: `item(id:)`, `create(_:)`, `update(_:)`.
+- `RecipeRepository`: `recipe(id:)`, `create(_:)`, `update(_:)`.
+- `SearchRepository`: `searchItemsAndRecipes(_:)`, `searchItems(_:)`.
+- `SuggestionsRepository` (or fold into Diary): `recent()`, `topAroundHour()`,
+  `topLogged()`.
+- `TargetsRepository`: `get()`, `save(_:)` (upsert), with in-memory session cache.
+
+---
+
+## 3. Util — ported calculations (`Util/`, PRD §7.1, §4.2) — MUST be unit-tested
+
+Port **exactly** from `web/src/DiaryList.tsx` and
+`web/src/WeeklyStatsCalculations.ts`. These are the highest-value tests and the
+only ones mandated by the minimal scope (§12, §13).
+
+### 3.1 `MacroCalculations.swift`
+```
+// recipeTotalForKey: web DiaryList.tsx:40
+recipeTotal(key, recipe) =
+  sum(item.servings * item.nutritionItem[key]) / max(recipe.totalServings, 1)
+
+// entryTotalMacro: web DiaryList.tsx:55
+entryTotal(key, entry) =
+  entry.servings * ((entry.nutritionItem?[key] ?? 0) + recipeTotal(key, entry.recipe))
+
+// totalMacro across a day: web DiaryList.tsx:60
+dayTotal(key, entries) = entries.reduce(0) { $0 + entryTotal(key, $1) }
+```
+- `key` ∈ {`protein_grams`, `dietary_fiber_grams`, `added_sugars_grams`,
+  `calories`}. Model as a `KeyPath<NutritionItem, Double>` or an enum mapping.
+- Per-day **calories** ring uses the server-computed `entry.calories` summed and
+  `ceil`-ed (web `DiaryList.tsx:195`), **not** `entryTotal(calories)`. Match this:
+  `dayCalories = ceil(entries.reduce(0){ $0 + $1.calories })`.
+- Per-entry display rounding: `round(entry.calories)`, `round(entryTotal(protein))`,
+  `round(entryTotal(fiber))` (web `DiaryList.tsx:233-241`).
+
+### 3.2 `WeeklyStats.swift` (port `WeeklyStatsCalculations.ts`)
+```
+calculateDaysBetween(start, end) = max(1, floor((end - start) / 86_400_000ms))
+calculateDailyAverage(total, days) = ceil(total / days)         // Math.ceil
+calculateFourWeeksDays(now) = calculateDaysBetween(startOfDay(now - 4w), startOfDay(now))
+```
+- "Last 7 Days" uses `currentWeekDays = 7` (fixed window, web `DiaryList.tsx:116`).
+- "4 Week Avg" uses `calculateFourWeeksDays(now)`.
+- Aggregate sums may be `null` → coalesce to 0 (web uses `|| 0`).
+
+### 3.3 `DateHelpers.swift`
+- `localDay(timestamp)` = start of day in **local** tz (web uses
+  `formatISO(startOfDay(parseISO(ts)))`, `DiaryList.tsx:32`). Group entries by this.
+- Page window math (web `DiaryList.tsx:92`):
+  `pageStart(page) = startOfDay(now - (PAGE_DAYS-1 + page*PAGE_DAYS) days)` as
+  ISO/UTC; `PAGE_DAYS = 7`. `entries(page)` queries
+  `[pageStart(page), page>0 ? pageStart(page-1) : nil)`.
+- Weekly-stats anchors (web `DiaryList.tsx:107-109`): `todayStart =
+  startOfDay(now)`, `sevenDaysAgoStart = startOfDay(now-7d)`,
+  `fourWeeksAgoStart = startOfDay(now-4w)`.
+- Display formatters: time (`parseAndFormatTime`) and day badge, local tz.
+- **All date logic is timezone-sensitive** — tests run with
+  `TZ=America/Los_Angeles` (PRD §12, matches web).
+
+---
+
+## 4. Feature: Diary list (home) — `Features/Diary/` (PRD §4.2)
+
+`DiaryListViewModel` (`@Observable @MainActor`): owns `page`, `entries`,
+`weeklyStats`, `targets`, and `loading/loaded/error`. On `.task`: load page 0
+entries + weekly stats + targets concurrently (`async let`).
+
+`DiaryListView`:
+- **Header band:** "Last 7 Days" avg kcal/day and "4-Week Avg" kcal/day from
+  `WeeklyStats`. "View Trends" link **hidden/deferred** in v1 (PRD §4.2).
+- **Grouping:** entries by `localDay`, days **descending**, entries within a day
+  **ascending** by `consumed_at` (§3.3, web parity).
+- **Per-day rings** (4× `MacroRing`, see §10): Calories (target + max), Protein g,
+  Fiber g, Added Sugar g (`isLimit = true`). Values from §3.1.
+- **Per-entry row:** `round(calories)` kcal, `round(entryTotal(protein))`g
+  protein, `round(entryTotal(fiber))`g fiber; item/recipe name (tappable →
+  detail); **RECIPE badge** when `entry.recipe != nil`; serving count + time
+  ("N servings at h:mma"); Edit + Delete affordances.
+- **Paging:** "← Previous Week" always; "Next Week →" only when `page > 0`
+  (web parity); disable while loading.
+- **Empty state:** "No entries this week." when the page has none.
+- **Delete:** optimistic removal + **rollback on failure** (web `deleteEntry`,
+  `DiaryList.tsx:335`): remove from the in-memory list, call `DeleteEntry`; if the
+  response has no `data`/throws, restore the entry.
+
+## 5. Feature: Add / edit entry — `Features/Entry/` (PRD §4.3)
+
+`EntryFormViewModel` handles both new and edit.
+
+**New entry** (`NewEntryView`, presented as a sheet or pushed):
+- Two modes via a segmented control (web `NewDiaryEntryForm.tsx`): **Suggestions**
+  and **Search**.
+- **Suggestions** (three sources, each its own query, §1):
+  1. "Logged at this time of day" — `TopEntriesAroundHour` with `startHour =
+     max(0, utcHour-1)`, `endHour = min(23, utcHour+1)` (web `NewDiaryEntryForm.tsx:64`).
+  2. "Recently logged" — `GetRecentEntryItems`.
+  3. "Most logged" — client-side merge of last-100 `GetTopLoggedItems`: count by
+     `item_<id>`/`recipe_<id>`, sort desc by count, take top 5 (port the
+     `Map`-based merge, `NewDiaryEntryForm.tsx:78-101`).
+  - Empty: "No suggestions available" when all three are empty.
+- **Search** — typeahead over `SearchItemsAndRecipes`; each result is a
+  "loggable" row.
+- **LoggableItem** (port `NewDiaryEntryForm.tsx:173`): expand to a servings
+  field (default 1, decimal), Save → `CreateDiaryEntry` with `{servings,
+  nutrition_item_id}` **xor** `{servings, recipe_id}`, brief ✔ confirmation.
+- `consumed_at` defaults to now; allow setting it (the web quick-add uses now;
+  iOS adds a date/time picker for parity with edit).
+
+**Edit entry** (`EditEntryView`): load via `GetDiaryEntry`; edit **servings** and
+**consumed_at**; Save → `UpdateDiaryEntry($id, {servings, consumed_at})`; Delete
+from this screen → `DeleteEntry` then pop.
+
+## 6. Feature: Nutrition items — `Features/Items/` (PRD §4.4)
+
+- **Create** (`ItemFormView` + `ItemFormViewModel`): full macro set — description,
+  calories, total/saturated/trans/poly/mono fat, cholesterol mg, sodium mg, total
+  carbs, fiber, total sugars, added sugars, protein. Numeric fields use decimal
+  keypads. Save → `CreateNutritionItem` (input encoded snake_case). The web's
+  camera-scan and LLM-autofill buttons are **deferred** (Phase 3) — form is manual
+  entry only (PRD §4.4).
+- **View** (`ItemDetailView`): macro detail; entry point to Edit.
+- **Edit:** load `GetNutritionItem`, Save → `UpdateItem($id, $attrs)`.
+
+## 7. Feature: Recipes — `Features/Recipes/` (PRD §4.5)
+
+- **Create** (`RecipeFormView` + `RecipeFormViewModel`): name, total servings, and
+  a list of recipe items — each picked via `SearchItems` (existing items only;
+  nested new-item creation is out of scope, matching `web` TODO) + a servings
+  value. Save → `CreateRecipe` (nested `recipe_items: { data: [...] }`).
+- **View** (`RecipeDetailView`): computed calories + constituent items
+  (`GetRecipe`).
+- **Edit:** update attrs + **replace** recipe items (delete-then-insert in one
+  `UpdateRecipe` mutation, web parity).
+
+## 8. Feature: Nutrition targets — `Features/Targets/` (PRD §4.6, §9)
+
+`TargetsViewModel` + `TargetsView`: edit calories, calories max, protein g, fiber
+g, added sugar g. On appear: `GetNutritionTargets`; if no row →
+`NutritionTargets.default`. Save → `SetNutritionTargets` upsert. Cache in memory
+for the session; the diary list reads from the same `TargetsRepository` so rings
+update after a save (PRD §4.6).
+
+## 9. Feature: Profile / settings — `Features/Profile/` (PRD §4.7)
+
+`ProfileView`: show Auth0 user (name/email/picture from id_token/userinfo); link
+to **Edit nutrition targets**; **Developer** section (debug builds only, §10) with
+the backend environment switcher (production ↔ LAN host); **Log out** (clears
+Keychain + in-memory tokens, optionally opens `/v2/logout`, returns to login).
+
+## 10. Design system — `DesignSystem/` (PRD §6.2, decision #12)
+
+- `MacroRing.swift` — the signature progress ring. Port `CircleProgress.tsx`
+  semantics with **Swift Charts** or a `Canvas`/trimmed `Circle`:
+  - ratio = `value / (max ?? target)`; arc trimmed to `min(ratio, 1)`.
+  - **Color rules (exact):** if `isLimit` → red when `value > target`, else green.
+    Else if `max != nil && value > max` → red; else if `value >= target` → green;
+    else amber. (Web hex: `#f87171` red, `#4ade80` green, `#fbbf24` amber.)
+  - Center label = `round(value)` + optional unit.
+- `DateBadge.swift` — day badge (port `DateBadge.tsx`).
+- `Theme.swift` — colors/spacing; "native base + custom accents" (decision #12):
+  HIG foundations plus the signature ring colors above.
+
+---
+
+## 11. Error & session handling (PRD §4.1, §8)
+
+- Any `401/403` surviving a refresh → `APIError.unauthorized` → `AuthService`
+  signs out → root routes to login (wired in Phase 0; consumed here).
+- `APIError.graphQL` / `.transport` → user-facing message on the relevant
+  form/list screen with a retry affordance (online-only UX, PRD §14).
+- Each screen has explicit `loading` / `loaded` / `error` states (§6.1).
+
+---
+
+## 12. Tests added in Phase 1 (see `testing.md`)
+
+- `MacroCalculations` — entry/recipe/day math vs. fixtures ported from the web
+  test suite (parity).
+- `WeeklyStats` — daily-average + 4-week-days math.
+- `GraphQLClient` decoding — golden JSON → model for **each** operation, including
+  snake_case mapping and the item/recipe XOR.
+- Targets get/upsert decode.
+- Run with `TZ=America/Los_Angeles`.
+
+---
+
+## 13. Definition of Done (Phase 1 / PRD §15)
+
+- Diary list renders weekly pages with correct per-day rings and 7-day / 4-week
+  headers **matching the web app for the same data**.
+- Add/edit/delete entries (item and recipe) with search + suggestions; create/edit
+  items; create/edit recipes — all working against the live backend.
+- Targets persist on the server and drive the rings.
+- Delete is optimistic with rollback; expired-token → re-login works.
+- Mandatory unit tests pass in CI; manual test plan (§12) passes.
+</content>

--- a/ios/plans/phase-2-insights.md
+++ b/ios/plans/phase-2-insights.md
@@ -1,0 +1,55 @@
+# Phase 2 — Insights (Trends)
+
+**PRD coverage:** §11 Phase 2; §5 (Trends deferred from v1); §8 (deferred
+`GetWeeklyTrends`). Web reference: `web/src/Trends.tsx`, `fetchWeeklyTrends` and
+the `food_diary_trends_weekly` view.
+
+**Goal:** a Trends screen with weekly charts (calories, protein, added sugar)
+using **Swift Charts** (decision: native, no deps — §13). Un-hide the "View
+Trends" link that Phase 1 deferred on the diary header (§4.2).
+
+---
+
+## 1. Backend
+
+No backend change required — the `food_diary_trends_weekly` view and its Hasura
+tracking already exist (`graphql-engine/migrations/.../add_trends_weekly_view`,
+metadata `food_diary_trends_weekly.yaml`).
+
+## 2. API (`Api.swift`)
+
+Add `GetWeeklyTrends` (mirror `web/src/Api.ts:getWeeklyTrendsQuery`):
+```graphql
+query GetWeeklyTrends {
+  food_diary_trends_weekly { week_of_year protein calories added_sugar }
+}
+```
+Model `WeeklyTrendsData { weekOfYear: String, protein, calories, addedSugar:
+Double }` and a `TrendsRepository.weeklyTrends()`.
+
+## 3. Feature `Features/Trends/`
+
+- `TrendsViewModel` (`@Observable @MainActor`): load on `.task`, `loading/loaded/
+  error`.
+- `TrendsView`: one chart per metric (Calories, Protein, Added Sugar) over
+  `week_of_year`, using `Swift Charts` (`LineMark`/`BarMark`). Overlay the
+  relevant `NutritionTargets` value as a `RuleMark` reference line where it makes
+  sense (calories target, protein target, added-sugar limit) — reuse
+  `TargetsRepository`.
+- Match web ordering/labeling of `week_of_year`.
+
+## 4. Navigation
+
+- Add `.trends` to the route enum; push from the now-visible "View Trends" link in
+  the diary header (`Features/Diary`), and/or the toolbar menu.
+
+## 5. Tests
+
+- `GetWeeklyTrends` golden-JSON decode.
+- Any client-side transform of `week_of_year` (sorting/formatting) unit-tested.
+
+## 6. Definition of Done
+
+- Trends screen renders the three weekly series from real data, reachable from the
+  diary header; "View Trends" no longer hidden.
+</content>

--- a/ios/plans/phase-3-native-capture.md
+++ b/ios/plans/phase-3-native-capture.md
@@ -1,0 +1,68 @@
+# Phase 3 — Native Capture (Label Scan + LLM Autofill)
+
+**PRD coverage:** §11 Phase 3; §4.4 (deferred camera/LLM on the item form); §3 /
+§8 (`/labeller/upload`, `/llm/lookup` sidecars); §14 (confirm sidecar ingress auth
+before building). Web reference: `web/src/CameraModal.tsx`,
+`web/src/LLMLookupModal.tsx`, `lookupNutritionWithLLM` in `web/src/Api.ts`.
+
+**Goal:** add the two deferred autofill paths to the **nutrition item form**
+(Phase 1 §6): (a) camera nutrition-label scan via the Rust OCR sidecar
+`/labeller/upload`, and (b) LLM nutrition lookup via `/llm/lookup`. Both populate
+the macro fields; the user reviews/edits before saving.
+
+---
+
+## 0. Precondition (PRD §14)
+
+**Confirm the same Bearer JWT is accepted by `/labeller/*` and `/llm/*` via the
+ingress before building.** The web app calls `/llm/lookup` without an auth header
+(same-origin), but the native client must send `Authorization: Bearer <token>`
+from `AuthService`. Verify the ingress authorizes these routes with the user's
+Hasura JWT; if not, resolve the ingress/auth config first. This is the gating risk
+for the whole phase.
+
+## 1. Networking
+
+These sidecars are **REST, not GraphQL**. Add a small `SidecarClient` (or extend
+`GraphQLClient`'s transport) that POSTs to `{BASE}/llm/lookup` and
+`{BASE}/labeller/upload` with the bearer token. Base URL from `AppEnvironment`
+(same prod/debug switch as GraphQL, §10).
+
+- **LLM:** `POST /llm/lookup` `{ "description": String }` → `{ item: {...
+  snake_case macros...} }`. Map to `NutritionItemAttrs` defaulting missing fields
+  to 0 (port the field-by-field coercion in `lookupNutritionWithLLM`,
+  `web/src/Api.ts:838`). On non-2xx, surface `body.error ?? statusText`.
+- **Labeller:** `POST /labeller/upload` multipart with the captured image →
+  parsed macro fields (match the web `CameraModal` upload contract / response
+  shape). Map into `NutritionItemAttrs`.
+
+## 2. Capture & permissions
+
+- Camera via `VisionKit` `DataScannerViewController` or `AVFoundation` capture +
+  optional on-device **Vision** OCR pre-pass (PRD §11 "optional on-device Vision
+  pre-pass") to crop/deskew before upload. Start simple: capture a still →
+  upload; add the Vision pre-pass only if accuracy needs it.
+- `Info.plist`: `NSCameraUsageDescription`.
+
+## 3. Item form integration (`Features/Items/`)
+
+- Add two buttons to `ItemFormView` (parity with web): **Scan label** (camera
+  sheet → `/labeller/upload` → prefill) and **Look up** (text → `/llm/lookup` →
+  prefill).
+- Both populate the form fields and leave the user to review/correct before Save
+  (existing Phase 1 `CreateNutritionItem`/`UpdateItem` path unchanged).
+- Clear loading + error states per call.
+
+## 4. Tests
+
+- Response decoding for `/llm/lookup` (incl. missing fields → 0) and
+  `/labeller/upload`.
+- Error mapping (non-2xx → message).
+- Macro mapping into `NutritionItemAttrs`.
+
+## 5. Definition of Done
+
+- From the item form, a label photo prefills macros via the OCR sidecar, and a
+  text description prefills macros via the LLM sidecar; both authorize with the
+  user's JWT through the ingress; the user can edit and save.
+</content>

--- a/ios/plans/phase-4-data-portability.md
+++ b/ios/plans/phase-4-data-portability.md
@@ -1,0 +1,62 @@
+# Phase 4 — Data Portability (CSV Import / Export)
+
+**PRD coverage:** §11 Phase 4; §5 (CSV deferred from v1); §8 (deferred
+`ExportEntries*`, `InsertDiaryEntriesWithNewItems`). Web reference:
+`web/src/CSVExport.ts`, `web/src/CSVImport.ts`, `web/src/ExportDiaryEntries.tsx`,
+`web/src/ImportDiaryEntries.tsx`, and `fetchExportEntries` / `insertDiaryEntries`
+in `web/src/Api.ts`.
+
+**Goal:** CSV **export** (share sheet / Files) and CSV **import** (Files picker)
+of diary entries, reusing the existing backend operations and matching the web
+CSV format exactly for round-trip compatibility.
+
+---
+
+## 1. API (`Api.swift`)
+
+Add (mirror `web/src/Api.ts`):
+- `ExportEntries` and `ExportEntriesWithDateRange($startDate,$endDate)` — select
+  `servings, consumed_at, nutrition_item { ...nutritionItem }, recipe { name,
+  recipe_items { servings, nutrition_item { ...nutritionItem } } }`.
+- `InsertDiaryEntriesWithNewItems($entries)` — bulk insert entries with nested new
+  `nutrition_item { data: {...} }` (port `insertDiaryEntries`, including the
+  snake_case nesting).
+
+## 2. CSV format (port exactly — `web/src/CSVExport.ts` / `CSVImport.ts`)
+
+- **Reuse the web's column order, headers, quoting/escaping, and number
+  formatting verbatim** so files exported on web import on iOS and vice-versa.
+  Port the serializer/parser as pure Swift functions in `Util/CSV.swift` and
+  unit-test against the web's fixtures (this is the correctness crux).
+- Handle both item entries and recipe entries as the web does.
+
+## 3. Export feature (`Features/Export/`)
+
+- `ExportViewModel`: optional date range → `fetchExportEntries` → CSV string →
+  write to a temp file.
+- Present iOS **share sheet** (`UIActivityViewController` / `ShareLink`) and/or
+  save to **Files** (`fileExporter`). UTType `.commaSeparatedText`.
+
+## 4. Import feature (`Features/Import/`)
+
+- `ImportViewModel`: `fileImporter` (Files) → read CSV → parse to
+  `[NewDiaryEntry]` → preview/confirm → `insertDiaryEntries`.
+- Surface parse errors with row context; allow cancel before commit. Match the
+  web's validation behavior.
+
+## 5. Navigation
+
+- Add `.exportEntries` / `.importEntries` routes; expose from the Profile/Settings
+  toolbar menu.
+
+## 6. Tests
+
+- CSV serialize/parse round-trip vs. **web fixtures** (parity is the whole point).
+- `ExportEntries*` and `InsertDiaryEntriesWithNewItems` decode/encode.
+
+## 7. Definition of Done
+
+- Export produces a CSV (optionally date-ranged) shareable via the share sheet /
+  Files; import reads a CSV (incl. web-exported files) and inserts entries with
+  new items; formats are byte-compatible with the web app.
+</content>

--- a/ios/plans/phase-5-platform-polish.md
+++ b/ios/plans/phase-5-platform-polish.md
@@ -1,0 +1,64 @@
+# Phase 5+ — Platform Polish
+
+**PRD coverage:** §11 Phase 5+; §1.2 / §5 (non-goals deferred from v1: iPad
+layouts, offline cache, widgets/Shortcuts/HealthKit, App Store readiness).
+
+**Goal:** the long-tail platform work that the v1 architecture was designed to
+make additive. Each item below is independent; sequence by value. None require
+backend changes beyond what earlier phases established.
+
+---
+
+## 1. iPad adaptive layouts (§1.2, §5)
+
+- Move from iPhone-only portrait to adaptive: `NavigationSplitView` for
+  list/detail on regular width; size-class-aware layouts for the diary list,
+  forms, and trends.
+- Audit the single `NavigationStack` (decision #15) — likely becomes a
+  split-view-aware container on iPad while staying a stack on iPhone.
+- Enable iPad in deployment info; test landscape.
+
+## 2. Read cache / offline reads (§5, §14 mitigation)
+
+- Add **SwiftData** as a read-through cache for diary entries, items, recipes, and
+  targets (the PRD names SwiftData; iOS 18 target supports it). This is the planned
+  fix for the "online-only on poor connectivity" risk (§14).
+- Strategy: cache last-fetched results keyed by query window; show cached data
+  instantly, refresh in background, reconcile. **Reads only** — mutation queue /
+  offline editing remains a non-goal (§1.2) unless explicitly added later.
+- Keep the repository protocols (§6.1) as the seam: a caching repo decorator wraps
+  the network repo, so view models are unchanged.
+
+## 3. Widgets / Shortcuts (§5)
+
+- WidgetKit widget(s): today's macro rings (Calories/Protein/Fiber/Added Sugar)
+  reusing `MacroRing` + `MacroCalculations`. Requires a shared framework/app-group
+  for the calculation + model code (extract `Util/` + `Models/` into a shared
+  target).
+- App Intents / Shortcuts: "Log <item>" quick action driving `CreateDiaryEntry`.
+
+## 4. HealthKit (§5)
+
+- Optional read/write of dietary energy + macronutrients to HealthKit
+  (`HKQuantityType` energy, protein, fiber, sugar). Gate behind a Profile toggle
+  with `NSHealthShareUsageDescription` / `NSHealthUpdateUsageDescription`.
+- Decide direction (write logged entries → Health, and/or read Health data in);
+  start with write-on-log.
+
+## 5. App Store readiness (§1.2 non-goal for v1, target later)
+
+- Privacy nutrition labels, App Privacy details, support URL, marketing assets.
+- Account deletion path (App Store requirement) — wire to Auth0 + a backend
+  user-data deletion routine (new backend work; scope separately).
+- Review-proof the auth flow (`ASWebAuthenticationSession` is App-Store-friendly).
+- Promote from TestFlight-only (decision #1) to public release.
+
+---
+
+## Definition of Done (per item)
+
+Each sub-feature ships independently with: the additive code behind existing
+repository/protocol seams, its own unit tests where logic is non-trivial (cache
+reconciliation, HealthKit mapping, widget calculations reuse the Phase 1 tested
+`MacroCalculations`), and no regression to the v1 online-only path.
+</content>

--- a/ios/plans/testing.md
+++ b/ios/plans/testing.md
@@ -1,0 +1,79 @@
+# Testing & Quality
+
+**PRD coverage:** §6.5 (auth tests), §12 (mandatory v1 coverage, manual test
+plan, CI), decision #13 (minimal scope).
+
+**Framework:** Swift Testing (Xcode 16+, iOS 18). Target `FoodDiaryTests`.
+**Scope is deliberately minimal** (decision #13): unit-test the critical
+calculations, API decoding, error mapping, and the auth crypto/refresh logic —
+not the UI.
+
+---
+
+## 1. Mandatory unit coverage (§12)
+
+### 1.1 `MacroCalculations` (Phase 1, §7.1)
+Port the web app's calculation fixtures for **parity**:
+- `recipeTotal` — sum(servings × macro) / max(totalServings, 1); incl.
+  `totalServings = 0` → divide by 1.
+- `entryTotal` — servings × (itemMacro + recipeTotal); item-only, recipe-only.
+- `dayTotal` — sum across a day's entries.
+- Per-day calories ring = `ceil(sum(entry.calories))`; per-entry display rounding
+  = `round(...)` (match `web/src/DiaryList.tsx`).
+
+### 1.2 `WeeklyStats` (Phase 1)
+- `calculateDaysBetween` (min 1, floor of day diff).
+- `calculateDailyAverage` = `ceil(total / days)`; `total = 0` and `null→0` cases.
+- `calculateFourWeeksDays(now)` with fixed `now` values.
+- **Run with `TZ=America/Los_Angeles`** (date-sensitive, matches web).
+
+### 1.3 `GraphQLClient` decoding
+Golden JSON → model for **every** v1 operation (Phase 1 §1):
+- `GetEntries` (item entry, recipe entry, mixed day), `GetWeeklyStats`
+  (incl. `sum.calories = null`), search, suggestions, `GetNutritionItem`,
+  `GetRecipe`, `GetDiaryEntry`, `GetNutritionTargets`.
+- Assert **snake_case → camelCase** mapping and the **item/recipe XOR** on
+  `DiaryEntry`.
+- Assert input encoding (camelCase → snake_case) for `CreateNutritionItem`,
+  `UpdateItem`, recipe create/update inputs, and the targets upsert object.
+
+### 1.4 Error mapping
+- HTTP 401 and 403 → `APIError.unauthorized` (and triggers logout hook).
+- Non-empty GraphQL `errors` → `APIError.graphQL`.
+- Other non-2xx / `URLError` → `APIError.transport`.
+
+### 1.5 Auth (§6.5) — Phase 0
+- **PKCE:** `code_challenge = base64url(SHA256(verifier))` vs. **RFC 7636 known
+  vectors**.
+- **Authorize URL:** all params present and correctly percent-encoded
+  (`response_type`, `client_id`, `redirect_uri`, `scope` incl. `offline_access`,
+  `audience`, `code_challenge`, `code_challenge_method=S256`, `state`).
+- **JWT `exp` decoding:** base64url-decode payload, read `exp`; malformed token
+  falls back to `expires_in`.
+- **Refresh coalescing:** N concurrent `currentToken()` callers while expired ⇒
+  **exactly 1** token request (inject a counting fake token endpoint). This is the
+  marquee auth test.
+
+---
+
+## 2. Test doubles
+
+Repositories and the token endpoint are protocol-backed (PRD §6.1), so tests
+inject in-memory fakes. `GraphQLClient` decoding tests feed fixture `Data`
+directly to the decoder rather than hitting the network.
+
+---
+
+## 3. Manual test plan (§12, run before each TestFlight build)
+
+login/logout · log an item entry · log a recipe entry · edit servings/time ·
+delete with rollback · create item · create recipe · change targets and confirm
+rings update · week paging (prev/next, boundaries) · expired-token → re-login.
+
+---
+
+## 4. CI
+
+See [`ci.md`](ci.md). CI builds the app and runs this test bundle on PRs touching
+`ios/`, on a macOS runner with an iOS 18 simulator, `TZ=America/Los_Angeles` set.
+</content>

--- a/ios/plans/testing.md
+++ b/ios/plans/testing.md
@@ -8,6 +8,28 @@ plan, CI), decision #13 (minimal scope).
 calculations, API decoding, error mapping, and the auth crypto/refresh logic —
 not the UI.
 
+> **Sequencing:** this infrastructure is stood up **first**, during scaffolding
+> (Phase 0 §1.2), not after features exist. The test target and CI run against a
+> trivial walking-skeleton test before any auth/model/networking code, so every
+> later unit is added **test-first** against a pipeline that is already green.
+
+---
+
+## 0. Set up first (Phase 0 §1.2)
+
+Before writing feature code:
+1. Create the `FoodDiaryTests` Swift Testing target wired to the `FoodDiary`
+   scheme (`xcodebuild test` runs it).
+2. Add one trivial walking-skeleton `@Test` so the bundle is runnable and proves
+   the simulator destination works.
+3. Stand up the `test-ios` CI job ([`ci.md`](ci.md)) and require it green on the
+   first `ios/` PR — this establishes the standard for the project.
+4. Lock the conventions used everywhere after: Swift Testing `@Test`/`#expect`;
+   protocol-backed repositories + token endpoint for fakes; pure logic tested, UI
+   not; `TZ=America/Los_Angeles` for date-sensitive tests.
+
+Thereafter, each item in §1 lands in the **same change** as the code it covers.
+
 ---
 
 ## 1. Mandatory unit coverage (§12)


### PR DESCRIPTION
Add detailed, sequenced implementation plans under ios/plans/ that cover the
entirety of specs/2026-06-20-ios-app.md:

- README index mapping every plan to PRD sections/phases
- phase-0-foundation: project, custom OIDC (PKCE) auth, GraphQL client,
  models, DI, navigation, config
- phase-1-core-logging: diary list/rings/paging, entries, items, recipes,
  search, suggestions, targets, profile; ported macro/weekly calculations
- backend-nutrition-targets: the §9 additive Hasura migration + metadata
- auth0-testflight-setup: §16/§17 manual runbook + checklist
- testing and ci: §12 mandatory coverage and GitHub Actions
- phase-2..5: trends, native capture, CSV portability, platform polish

Plans are grounded in the existing web app (web/src/Api.ts, DiaryList.tsx,
WeeklyStatsCalculations.ts) and backend (graphql-engine) for parity.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V3Jjs7GWzNMc5siroSZU5Q