### PR TITLE
ios: restyle app to match web's Tailwind look instead of HIG native styling

### DIFF
--- a/ios/FoodDiary.xcodeproj/project.pbxproj
+++ b/ios/FoodDiary.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		58F03CBA8F34081755F97BC2 /* NewEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E97C9C39280FD2AEB04277 /* NewEntryView.swift */; };
 		5A768E74CD41762618A8705A /* ExportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EBB4BF38975CE2416316A3 /* ExportView.swift */; };
 		5A851786E2DF74472406F3A1 /* ErrorRetryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A098B0449ECB88A2B8789120 /* ErrorRetryView.swift */; };
+		A509137C54704738A87D7B3D /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44175F6573C445AC8B8B0E84 /* ButtonStyles.swift */; };
+		6F94F6BAFDC64A0D93B7BB91 /* WebStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75F35F154414315A30FBB2D /* WebStyle.swift */; };
 		5AC9D15E1CE036B93633E6B4 /* ExportEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF67E2EF77215BA27B403A6 /* ExportEntry.swift */; };
 		5BAA171496B5433984732D22 /* TargetsApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3F5AADC5694D6E92302AD3 /* TargetsApiTests.swift */; };
 		5E2C66C9FED8CE86FF65A954 /* RecipeFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE36C14FBC3749B731BD5E7 /* RecipeFormViewModel.swift */; };
@@ -207,6 +209,8 @@
 		9D07A77088CE849C76A5148D /* ExportViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExportViewModel.swift; path = ../FoodDiary/Features/Export/ExportViewModel.swift; sourceTree = "<group>"; };
 		9F9C360176FD063F67E81550 /* ItemFormViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ItemFormViewModel.swift; path = ../FoodDiary/Features/Items/ItemFormViewModel.swift; sourceTree = "<group>"; };
 		A098B0449ECB88A2B8789120 /* ErrorRetryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorRetryView.swift; path = ../FoodDiary/DesignSystem/ErrorRetryView.swift; sourceTree = "<group>"; };
+		44175F6573C445AC8B8B0E84 /* ButtonStyles.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ButtonStyles.swift; path = DesignSystem/ButtonStyles.swift; sourceTree = "<group>"; };
+		A75F35F154414315A30FBB2D /* WebStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WebStyle.swift; path = DesignSystem/WebStyle.swift; sourceTree = "<group>"; };
 		A239B9B25CCD9978A75DCFBC /* MacroCalculations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroCalculations.swift; sourceTree = "<group>"; };
 		A256459B4D7448DEAE5309B9 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		A38EFD9F6A7F42849AB6E534 /* NutritionItemInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NutritionItemInput.swift; sourceTree = "<group>"; };
@@ -440,6 +444,8 @@
 				59A2521C603F9C92E89F1629 /* MacroRing.swift */,
 				5A6A128A0233D0F08A808E84 /* DateBadge.swift */,
 				A098B0449ECB88A2B8789120 /* ErrorRetryView.swift */,
+				44175F6573C445AC8B8B0E84 /* ButtonStyles.swift */,
+				A75F35F154414315A30FBB2D /* WebStyle.swift */,
 			);
 			name = DesignSystem;
 			sourceTree = "<group>";
@@ -755,6 +761,8 @@
 				FD76A8799E27877A1A7E8296 /* ProfileViewModel.swift in Sources */,
 				DD392B21051F283CD9E77A38 /* ProfileView.swift in Sources */,
 				5A851786E2DF74472406F3A1 /* ErrorRetryView.swift in Sources */,
+				A509137C54704738A87D7B3D /* ButtonStyles.swift in Sources */,
+				6F94F6BAFDC64A0D93B7BB91 /* WebStyle.swift in Sources */,
 				CF885D028666BFC97D7E25AB /* TrendsViewModel.swift in Sources */,
 				CDCDF521A81268BE80C123AB /* WeeklyTrendsData.swift in Sources */,
 				0888032955783EC87C6DF9FA /* TrendsView.swift in Sources */,

--- a/ios/FoodDiary/App/AdaptiveRootView.swift
+++ b/ios/FoodDiary/App/AdaptiveRootView.swift
@@ -31,6 +31,7 @@ struct AdaptiveRootView<Sidebar: View, Detail: View>: View {
                         description: Text("Choose an entry, item, or recipe to see details."))
                 }
             }
+            .webScreenStyle()
         } else {
             NavigationStack(path: Bindable(router).path) {
                 sidebar()
@@ -38,6 +39,7 @@ struct AdaptiveRootView<Sidebar: View, Detail: View>: View {
                         destination(route)
                     }
             }
+            .webScreenStyle()
         }
     }
 }

--- a/ios/FoodDiary/App/FoodDiaryApp.swift
+++ b/ios/FoodDiary/App/FoodDiaryApp.swift
@@ -1,12 +1,39 @@
 import SwiftUI
+import UIKit
 
 @main
 struct FoodDiaryApp: App {
     @State private var environment = AppEnvironment()
 
+    init() {
+        FoodDiaryApp.configureWebStyleAppearance()
+    }
+
     var body: some Scene {
         WindowGroup {
             RootView(environment: environment)
+                .tint(Theme.accent)
         }
+    }
+
+    /// Matches the flat, borderless `bg-slate-50` header in `web/src/App.tsx`:
+    /// no translucent blur or shadow line under the nav/tab bars.
+    private static func configureWebStyleAppearance() {
+        let navAppearance = UINavigationBarAppearance()
+        navAppearance.configureWithOpaqueBackground()
+        navAppearance.backgroundColor = UIColor(Theme.background)
+        navAppearance.shadowColor = .clear
+        navAppearance.titleTextAttributes = [.foregroundColor: UIColor(Theme.textPrimary)]
+        navAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor(Theme.textPrimary)]
+        UINavigationBar.appearance().standardAppearance = navAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = navAppearance
+        UINavigationBar.appearance().compactAppearance = navAppearance
+
+        let tabAppearance = UITabBarAppearance()
+        tabAppearance.configureWithOpaqueBackground()
+        tabAppearance.backgroundColor = UIColor(Theme.background)
+        tabAppearance.shadowColor = .clear
+        UITabBar.appearance().standardAppearance = tabAppearance
+        UITabBar.appearance().scrollEdgeAppearance = tabAppearance
     }
 }

--- a/ios/FoodDiary/App/LoginView.swift
+++ b/ios/FoodDiary/App/LoginView.swift
@@ -7,6 +7,7 @@ struct LoginView: View {
         VStack(spacing: 24) {
             Text("Food Diary")
                 .font(.largeTitle.bold())
+                .foregroundStyle(Theme.textPrimary)
 
             switch authService.state {
             case .signingIn:
@@ -15,9 +16,11 @@ struct LoginView: View {
                 Button("Log In") {
                     Task { await authService.login() }
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.webPrimary)
             }
         }
         .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .webScreenStyle()
     }
 }

--- a/ios/FoodDiary/DesignSystem/ButtonStyles.swift
+++ b/ios/FoodDiary/DesignSystem/ButtonStyles.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Filled indigo pill button matching `web/src/ButtonLink.tsx`
+/// (`bg-indigo-600 text-slate-50 py-2 px-3 text-lg rounded-md`).
+struct PrimaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 17, weight: .regular))
+            .foregroundStyle(Theme.badgeForeground)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 12)
+            .background(
+                (configuration.isPressed ? Theme.accentPressed : Theme.accent),
+                in: RoundedRectangle(cornerRadius: Theme.cornerRadius)
+            )
+    }
+}
+
+/// Underlined indigo text link matching the `text-indigo-600 hover:text-indigo-800
+/// underline` pattern used throughout `web/src` for secondary actions.
+struct LinkButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundStyle(configuration.isPressed ? Theme.accentPressed : Theme.accent)
+            .underline()
+    }
+}
+
+extension ButtonStyle where Self == PrimaryButtonStyle {
+    static var webPrimary: PrimaryButtonStyle { PrimaryButtonStyle() }
+}
+
+extension ButtonStyle where Self == LinkButtonStyle {
+    static var webLink: LinkButtonStyle { LinkButtonStyle() }
+}

--- a/ios/FoodDiary/DesignSystem/DateBadge.swift
+++ b/ios/FoodDiary/DesignSystem/DateBadge.swift
@@ -12,6 +12,7 @@ struct DateBadge: View {
             Text(DateBadgeFormatting.monthAbbreviation(date))
                 .font(.system(size: 16, weight: .semibold))
         }
+        .foregroundStyle(Theme.textPrimary)
         .multilineTextAlignment(.center)
     }
 }

--- a/ios/FoodDiary/DesignSystem/ErrorRetryView.swift
+++ b/ios/FoodDiary/DesignSystem/ErrorRetryView.swift
@@ -9,8 +9,9 @@ struct ErrorRetryView: View {
 
     var body: some View {
         VStack(spacing: 12) {
-            Text(message).foregroundStyle(.red)
+            Text(message).foregroundStyle(Theme.red600)
             Button("Retry", action: retry)
+                .buttonStyle(.webPrimary)
         }
     }
 }

--- a/ios/FoodDiary/DesignSystem/MacroRing.swift
+++ b/ios/FoodDiary/DesignSystem/MacroRing.swift
@@ -43,7 +43,7 @@ struct MacroRing: View {
             Text(label)
                 .font(.caption)
                 .textCase(.uppercase)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Theme.textSecondary)
         }
     }
 }

--- a/ios/FoodDiary/DesignSystem/Theme.swift
+++ b/ios/FoodDiary/DesignSystem/Theme.swift
@@ -1,13 +1,48 @@
 import SwiftUI
 
-/// "Native base + custom accents" (PRD decision #12): HIG colors everywhere except
-/// the signature ring colors, which must match `web/src/CircleProgress.tsx` exactly
-/// (`#f87171` red, `#4ade80` green, `#fbbf24` amber) for cross-platform parity.
+/// Web-matched design tokens: the app now mirrors the Tailwind palette used by
+/// `web/src` (slate neutrals, indigo accent, amber/green/red ring colors) instead
+/// of HIG system colors, so the two clients look and feel like the same product.
 enum Theme {
+    // Tailwind slate scale, used for backgrounds/text/borders across web/src.
+    static let slate50 = Color(red: 0xf8 / 255, green: 0xfa / 255, blue: 0xfc / 255)
+    static let slate100 = Color(red: 0xf1 / 255, green: 0xf5 / 255, blue: 0xf9 / 255)
+    static let slate200 = Color(red: 0xe2 / 255, green: 0xe8 / 255, blue: 0xf0 / 255)
+    static let slate300 = Color(red: 0xcb / 255, green: 0xd5 / 255, blue: 0xe1 / 255)
+    static let slate400 = Color(red: 0x94 / 255, green: 0xa3 / 255, blue: 0xb8 / 255)
+    static let slate700 = Color(red: 0x33 / 255, green: 0x41 / 255, blue: 0x55 / 255)
+    static let slate800 = Color(red: 0x1e / 255, green: 0x29 / 255, blue: 0x3b / 255)
+
+    // Tailwind indigo scale, the web app's link/button accent.
+    static let indigo600 = Color(red: 0x4f / 255, green: 0x46 / 255, blue: 0xe5 / 255)
+    static let indigo700 = Color(red: 0x43 / 255, green: 0x38 / 255, blue: 0xca / 255)
+    static let indigo800 = Color(red: 0x37 / 255, green: 0x30 / 255, blue: 0xa3 / 255)
+
+    static let red600 = Color(red: 0xdc / 255, green: 0x26 / 255, blue: 0x26 / 255)
+
+    // Trends chart line colors, matched to web/src/Trends.tsx's inline hexes.
+    static let chartBlue = Color(red: 0x3b / 255, green: 0x82 / 255, blue: 0xf6 / 255)
+    static let chartGreen = Color(red: 0x10 / 255, green: 0xb9 / 255, blue: 0x81 / 255)
+    static let chartRed = Color(red: 0xef / 255, green: 0x44 / 255, blue: 0x44 / 255)
+    static let chartGridline = Color(red: 0xe5 / 255, green: 0xe7 / 255, blue: 0xeb / 255)
+
+    static let background = slate50
+    static let surface = slate50
+    static let textPrimary = slate800
+    static let textSecondary = slate700
+    static let textMuted = slate400
+    static let border = slate200
+    static let accent = indigo600
+    static let accentPressed = indigo800
+    static let badgeBackground = slate400
+    static let badgeForeground = slate50
+
+    static let cornerRadius: CGFloat = 6
+
     static let ringRed = Color(red: 0xf8 / 255, green: 0x71 / 255, blue: 0x71 / 255)
     static let ringGreen = Color(red: 0x4a / 255, green: 0xde / 255, blue: 0x80 / 255)
     static let ringAmber = Color(red: 0xfb / 255, green: 0xbf / 255, blue: 0x24 / 255)
-    static let ringTrack = Color(.systemGray4)
+    static let ringTrack = slate200
 
     static func ringColor(_ color: RingColor) -> Color {
         switch color {

--- a/ios/FoodDiary/DesignSystem/WebStyle.swift
+++ b/ios/FoodDiary/DesignSystem/WebStyle.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// Strips iOS's grouped-list chrome (inset cards, system gray backgrounds) so
+/// `List`/`Form` read as the flat, single-column layout `web/src` uses.
+struct WebListStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .scrollContentBackground(.hidden)
+            .listStyle(.plain)
+            .background(Theme.background)
+    }
+}
+
+/// Flat slate-50 screen background, used on non-list screens to match the
+/// `bg-slate-50` body background in `web/src/App.tsx`.
+struct WebScreenStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(Theme.background)
+    }
+}
+
+extension View {
+    func webListStyle() -> some View {
+        modifier(WebListStyle())
+    }
+
+    func webScreenStyle() -> some View {
+        modifier(WebScreenStyle())
+    }
+}

--- a/ios/FoodDiary/Features/Diary/DiaryListView.swift
+++ b/ios/FoodDiary/Features/Diary/DiaryListView.swift
@@ -46,7 +46,7 @@ struct DiaryListView: View {
             }
             if viewModel.groupedEntries.isEmpty {
                 Text("No entries this week.")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(Theme.textMuted)
             } else {
                 ForEach(viewModel.groupedEntries) { group in
                     Section {
@@ -59,6 +59,7 @@ struct DiaryListView: View {
             }
             pagingControls
         }
+        .webListStyle()
     }
 
     private func weeklyStatsHeader(_ stats: WeeklyStatsTotals) -> some View {
@@ -68,13 +69,16 @@ struct DiaryListView: View {
         return HStack {
             VStack {
                 Text("\(sevenDayAvg) kcal/day")
-                Text("Last 7 Days").font(.caption).foregroundStyle(.secondary)
+                Text("Last 7 Days").font(.caption).foregroundStyle(Theme.textSecondary)
             }
             Spacer()
             VStack {
                 Text("\(fourWeekAvg) kcal/day")
-                Text("4 Week Avg").font(.caption).foregroundStyle(.secondary)
+                Text("4 Week Avg").font(.caption).foregroundStyle(Theme.textSecondary)
             }
+            Spacer()
+            Button("View Trends") { router.push(.trends) }
+                .buttonStyle(.webLink)
         }
     }
 
@@ -111,9 +115,10 @@ struct DiaryListView: View {
             HStack {
                 Text("\(servingsLabel(entry.servings)) at \(entry.consumedAt.formatted(date: .omitted, time: .shortened))")
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(Theme.textSecondary)
                 Spacer()
                 Button("Edit") { router.push(.editEntry(entry.id)) }
+                    .buttonStyle(.webLink)
                 Button("Delete", role: .destructive) {
                     Task { await viewModel.delete(entry) }
                 }
@@ -122,8 +127,8 @@ struct DiaryListView: View {
                 Text("RECIPE")
                     .font(.caption2)
                     .padding(.horizontal, 6).padding(.vertical, 2)
-                    .background(.secondary, in: RoundedRectangle(cornerRadius: 4))
-                    .foregroundStyle(.white)
+                    .background(Theme.badgeBackground, in: RoundedRectangle(cornerRadius: 4))
+                    .foregroundStyle(Theme.badgeForeground)
             }
         }
     }
@@ -135,10 +140,12 @@ struct DiaryListView: View {
     private var pagingControls: some View {
         HStack {
             Button("← Previous Week") { Task { await viewModel.goToPreviousWeek() } }
+                .buttonStyle(.webLink)
                 .disabled(viewModel.state == .loading)
             Spacer()
             if viewModel.canGoToNextWeek {
                 Button("Next Week →") { Task { await viewModel.goToNextWeek() } }
+                    .buttonStyle(.webLink)
                     .disabled(viewModel.state == .loading)
             }
         }

--- a/ios/FoodDiary/Features/Entry/EditEntryView.swift
+++ b/ios/FoodDiary/Features/Entry/EditEntryView.swift
@@ -33,7 +33,10 @@ struct EditEntryView: View {
             Stepper("Servings: \(viewModel.servings.formatted())", value: $viewModel.servings, in: 0.1...50, step: 0.1)
             DatePicker("Consumed at", selection: $viewModel.consumedAt)
             Button("Save") { Task { await viewModel.save() } }
+                .buttonStyle(.webPrimary)
+                .listRowBackground(Color.clear)
             Button("Delete", role: .destructive) { Task { await viewModel.delete() } }
         }
+        .webListStyle()
     }
 }

--- a/ios/FoodDiary/Features/Entry/NewEntryView.swift
+++ b/ios/FoodDiary/Features/Entry/NewEntryView.swift
@@ -20,6 +20,7 @@ struct NewEntryView: View {
                 searchContent
             }
         }
+        .webListStyle()
         .navigationTitle("Add Entry")
         .task {
             await viewModel.loadSuggestions()
@@ -50,7 +51,7 @@ struct NewEntryView: View {
             }
         }
         if viewModel.hasNoSuggestions {
-            Text("No suggestions available").foregroundStyle(.secondary)
+            Text("No suggestions available").foregroundStyle(Theme.textMuted)
         }
     }
 
@@ -92,9 +93,17 @@ private struct LoggableItemRow: View {
                 isExpanded.toggle()
             } label: {
                 HStack {
-                    Text(name)
+                    Text("⊕")
+                        .font(.title2)
+                        .foregroundStyle(Theme.accent)
+                        .rotationEffect(.degrees(isExpanded ? 45 : 0))
+                    Text(name).foregroundStyle(Theme.textPrimary)
                     if kind == .recipe {
-                        Text("RECIPE").font(.caption2).foregroundStyle(.secondary)
+                        Text("RECIPE")
+                            .font(.caption2)
+                            .padding(.horizontal, 6).padding(.vertical, 2)
+                            .background(Theme.badgeBackground, in: RoundedRectangle(cornerRadius: 4))
+                            .foregroundStyle(Theme.badgeForeground)
                     }
                 }
             }
@@ -102,11 +111,12 @@ private struct LoggableItemRow: View {
                 Stepper("Servings: \(servings.formatted())", value: $servings, in: 0.1...50, step: 0.1)
                 DatePicker("Consumed at", selection: $consumedAt)
                 if let saveError = viewModel.saveError {
-                    Text(saveError).foregroundStyle(.red)
+                    Text(saveError).foregroundStyle(Theme.red600)
                 }
                 Button(isSaving ? "Saving..." : "Save") {
                     Task { await save() }
                 }
+                .buttonStyle(.webPrimary)
                 .disabled(isSaving)
             }
         }

--- a/ios/FoodDiary/Features/Export/ExportView.swift
+++ b/ios/FoodDiary/Features/Export/ExportView.swift
@@ -18,11 +18,14 @@ struct ExportView: View {
             }
             Section {
                 Button("Export") { Task { await viewModel.export() } }
+                    .buttonStyle(.webPrimary)
+                    .listRowBackground(Color.clear)
                 if let errorMessage = viewModel.errorMessage {
                     ErrorRetryView(message: errorMessage) { Task { await viewModel.export() } }
                 }
             }
         }
+        .webListStyle()
         .navigationTitle("Export Entries")
         .fileExporter(
             isPresented: $isExporting,

--- a/ios/FoodDiary/Features/Import/ImportView.swift
+++ b/ios/FoodDiary/Features/Import/ImportView.swift
@@ -13,11 +13,13 @@ struct ImportView: View {
         Form {
             Section {
                 Button("Choose CSV File") { isPickingFile = true }
+                    .buttonStyle(.webPrimary)
+                    .listRowBackground(Color.clear)
             }
             if !viewModel.parseErrors.isEmpty {
                 Section("Errors") {
                     ForEach(Array(viewModel.parseErrors.enumerated()), id: \.offset) { _, message in
-                        Text(message).foregroundStyle(.red)
+                        Text(message).foregroundStyle(Theme.red600)
                     }
                 }
             }
@@ -29,12 +31,15 @@ struct ImportView: View {
                 }
                 Section {
                     Button("Import") { Task { await viewModel.confirm() } }
+                        .buttonStyle(.webPrimary)
+                        .listRowBackground(Color.clear)
                 }
             }
             if let errorMessage = viewModel.errorMessage {
                 ErrorRetryView(message: errorMessage) { Task { await viewModel.confirm() } }
             }
         }
+        .webListStyle()
         .navigationTitle("Import Entries")
         .fileImporter(isPresented: $isPickingFile, allowedContentTypes: [.commaSeparatedText]) { result in
             if let url = try? result.get(), let csv = try? String(contentsOf: url, encoding: .utf8) {

--- a/ios/FoodDiary/Features/Items/CameraCaptureView.swift
+++ b/ios/FoodDiary/Features/Items/CameraCaptureView.swift
@@ -96,7 +96,7 @@ struct CameraCaptureView: View {
         NavigationStack {
             ZStack {
                 if let configurationError {
-                    Text(configurationError).foregroundStyle(.red).padding()
+                    Text(configurationError).foregroundStyle(Theme.red600).padding()
                 } else {
                     CameraPreviewView(session: controller.session)
                         .ignoresSafeArea()

--- a/ios/FoodDiary/Features/Items/ItemDetailView.swift
+++ b/ios/FoodDiary/Features/Items/ItemDetailView.swift
@@ -46,13 +46,17 @@ struct ItemDetailView: View {
             macroRow("Added Sugars (g)", item.addedSugarsGrams)
             macroRow("Protein (g)", item.proteinGrams, bold: true)
         }
+        .webListStyle()
     }
 
     private func macroRow(_ title: String, _ value: Double, bold: Bool = false) -> some View {
         HStack {
-            Text(title).fontWeight(bold ? .semibold : .regular)
+            Text(title)
+                .fontWeight(bold ? .semibold : .regular)
+                .foregroundStyle(Theme.textPrimary)
             Spacer()
             Text(value.formatted())
+                .foregroundStyle(Theme.textPrimary)
         }
     }
 }

--- a/ios/FoodDiary/Features/Items/ItemFormView.swift
+++ b/ios/FoodDiary/Features/Items/ItemFormView.swift
@@ -46,7 +46,7 @@ struct ItemFormView: View {
                 if viewModel.lookupState == .loading {
                     ProgressView("Looking up...")
                 } else if case .error(let message) = viewModel.lookupState {
-                    Text(message).foregroundStyle(.red)
+                    Text(message).foregroundStyle(Theme.red600)
                 }
 
                 Button("Scan Label") { showCamera = true }
@@ -54,7 +54,7 @@ struct ItemFormView: View {
                 if viewModel.scanState == .loading {
                     ProgressView("Scanning label...")
                 } else if case .error(let message) = viewModel.scanState {
-                    Text(message).foregroundStyle(.red)
+                    Text(message).foregroundStyle(Theme.red600)
                 }
             }
             Section {
@@ -77,8 +77,11 @@ struct ItemFormView: View {
             }
             Section {
                 Button("Save") { Task { await viewModel.save() } }
+                    .buttonStyle(.webPrimary)
+                    .listRowBackground(Color.clear)
             }
         }
+        .webListStyle()
     }
 
     private func numericField(_ title: String, value: Binding<Double>) -> some View {

--- a/ios/FoodDiary/Features/Profile/ProfileView.swift
+++ b/ios/FoodDiary/Features/Profile/ProfileView.swift
@@ -23,21 +23,26 @@ struct ProfileView: View {
                     }
                     .frame(width: 64, height: 64)
                     .clipShape(Circle())
+                    .overlay(Circle().stroke(Theme.textPrimary, lineWidth: 1))
                 }
                 Text(viewModel.name ?? "Signed in")
                     .font(.headline)
+                    .foregroundStyle(Theme.textPrimary)
                 if let email = viewModel.email {
-                    Text(email).foregroundStyle(.secondary)
+                    Text(email).foregroundStyle(Theme.textSecondary)
                 }
             }
 
             Section {
                 Button("Edit Nutrition Targets", action: onEditTargets)
+                    .buttonStyle(.webLink)
             }
 
             Section("Data") {
                 Button("Export Entries", action: onExport)
+                    .buttonStyle(.webLink)
                 Button("Import Entries", action: onImport)
+                    .buttonStyle(.webLink)
             }
 
             #if DEBUG
@@ -46,7 +51,7 @@ struct ProfileView: View {
                     Text("Using custom backend").foregroundStyle(.orange)
                     Button("Reset to Production") { viewModel.resetToProductionBackend() }
                 } else {
-                    Text("Using production backend").foregroundStyle(.secondary)
+                    Text("Using production backend").foregroundStyle(Theme.textSecondary)
                 }
                 TextField("LAN host", text: $customHost)
                     .keyboardType(.URL)
@@ -64,6 +69,7 @@ struct ProfileView: View {
                 }
             }
         }
+        .webListStyle()
         .navigationTitle("Profile")
     }
 }

--- a/ios/FoodDiary/Features/Recipes/RecipeDetailView.swift
+++ b/ios/FoodDiary/Features/Recipes/RecipeDetailView.swift
@@ -46,18 +46,19 @@ struct RecipeDetailView: View {
             }
             Section("Ingredients") {
                 if recipe.recipeItems.isEmpty {
-                    Text("No recipe items.").foregroundStyle(.secondary)
+                    Text("No recipe items.").foregroundStyle(Theme.textSecondary)
                 } else {
                     ForEach(recipe.recipeItems, id: \.nutritionItem.id) { item in
                         VStack(alignment: .leading) {
                             Text(item.nutritionItem.description)
                             Text("\(item.servings.formatted()) servings - \(Int(viewModel.calories(for: item).rounded())) kcal")
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(Theme.textSecondary)
                         }
                     }
                 }
             }
         }
+        .webListStyle()
     }
 }

--- a/ios/FoodDiary/Features/Recipes/RecipeFormView.swift
+++ b/ios/FoodDiary/Features/Recipes/RecipeFormView.swift
@@ -41,7 +41,7 @@ struct RecipeFormView: View {
             }
             Section("Items") {
                 if viewModel.items.isEmpty {
-                    Text("No items in recipe.").foregroundStyle(.secondary)
+                    Text("No items in recipe.").foregroundStyle(Theme.textSecondary)
                 } else {
                     ForEach(Array(viewModel.items.enumerated()), id: \.element.id) { index, item in
                         HStack {
@@ -70,13 +70,19 @@ struct RecipeFormView: View {
                     Button {
                         viewModel.addItem(result)
                     } label: {
-                        Text(result.name)
+                        HStack {
+                            Text("⊕").foregroundStyle(Theme.accent)
+                            Text(result.name).foregroundStyle(Theme.textPrimary)
+                        }
                     }
                 }
             }
             Section {
                 Button("Save Recipe") { Task { await viewModel.save() } }
+                    .buttonStyle(.webPrimary)
+                    .listRowBackground(Color.clear)
             }
         }
+        .webListStyle()
     }
 }

--- a/ios/FoodDiary/Features/Targets/TargetsView.swift
+++ b/ios/FoodDiary/Features/Targets/TargetsView.swift
@@ -39,8 +39,11 @@ struct TargetsView: View {
             }
             Section {
                 Button("Save Targets") { Task { await viewModel.save() } }
+                    .buttonStyle(.webPrimary)
+                    .listRowBackground(Color.clear)
             }
         }
+        .webListStyle()
     }
 
     private func numericField(_ title: String, value: Binding<Double>) -> some View {

--- a/ios/FoodDiary/Features/Trends/TrendsView.swift
+++ b/ios/FoodDiary/Features/Trends/TrendsView.swift
@@ -28,28 +28,28 @@ struct TrendsView: View {
     private var content: some View {
         if viewModel.trends.isEmpty {
             Text("No data available yet. Add some diary entries to see trends!")
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Theme.textSecondary)
                 .padding()
         } else {
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
                     chartSection(
                         title: "Average Daily Calories (per week)",
-                        color: .blue,
+                        color: Theme.chartBlue,
                         target: viewModel.targets.calories
                     ) { trend in
                         (trend.weekOfYear, trend.calories)
                     }
                     chartSection(
                         title: "Average Daily Protein (g per week)",
-                        color: .green,
+                        color: Theme.chartGreen,
                         target: viewModel.targets.proteinGrams
                     ) { trend in
                         (trend.weekOfYear, trend.protein)
                     }
                     chartSection(
                         title: "Average Daily Added Sugar (g per week)",
-                        color: .red,
+                        color: Theme.chartRed,
                         target: viewModel.targets.addedSugarsGrams
                     ) { trend in
                         (trend.weekOfYear, trend.addedSugar)
@@ -57,6 +57,7 @@ struct TrendsView: View {
                 }
                 .padding()
             }
+            .webScreenStyle()
         }
     }
 
@@ -81,9 +82,11 @@ struct TrendsView: View {
                     .foregroundStyle(color)
                 }
                 RuleMark(y: .value("Target", target))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(Theme.chartGridline)
                     .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
             }
+            .chartXAxis { AxisMarks { _ in AxisGridLine().foregroundStyle(Theme.chartGridline) } }
+            .chartYAxis { AxisMarks { _ in AxisGridLine().foregroundStyle(Theme.chartGridline) } }
             .frame(height: 200)
         }
     }


### PR DESCRIPTION
Replace system colors/chrome with web-matched design tokens (slate neutrals,
indigo accent) in Theme.swift, add PrimaryButtonStyle/LinkButtonStyle mirroring
web's ButtonLink and underlined-link patterns, and strip List/Form's native
grouped-card chrome via a webListStyle()/webScreenStyle() modifier pair so
every screen reads as the flat, single-column layout web/src uses. Apply
across all feature views (Diary, Items, Recipes, Entry, Profile, Targets,
Trends, Export, Import) plus global nav/tab bar appearance and tint.