### PR TITLE
Add OAuth refresh-token support to MCP server

### DIFF
--- a/docs/mcp-connector.md
+++ b/docs/mcp-connector.md
@@ -53,7 +53,7 @@ Claude calls a tool:
     → Returns data → MCP server returns tool result → Claude uses in response
 ```
 
-No credential storage on the server. No refresh token management. The JWT lives in Claude.ai's session, valid for the session lifetime. Auth0 handles re-auth when it expires.
+No credential storage on the server. Access tokens are 1-hour stateless JWTs. Alongside each access token the server issues a long-lived refresh token (default 30 days, sliding) so Claude.ai can renew silently via `grant_type=refresh_token` without prompting for login. The refresh token is itself a stateless signed JWT: it carries the Auth0 refresh token in an AES-256-GCM-encrypted `a0rt` claim (key derived from the Hasura JWT secret via HKDF), uses a distinct audience (`food-diary-mcp-refresh`) so it can never be replayed as an access token, and requires no server-side storage — deploys and restarts don't invalidate it. Each refresh round-trips Auth0's token endpoint (so revoking the Auth0 grant kills access) and returns a re-wrapped refresh token, which also makes Auth0 refresh-token rotation work transparently.
 
 ---
 
@@ -68,6 +68,12 @@ The current Auth0 application is a SPA (PKCE, no client secret). Claude.ai's OAu
 **Conclusion for now**: start by reusing the existing app (just add the callback URL). Create a second app later if you want cleaner separation.
 
 The Claude.ai connector callback URL is provided in the connector setup flow — typically `https://claude.ai/oauth/callback`. Add it to the existing app's Allowed Callback URLs in the Auth0 dashboard.
+
+**Refresh token checklist (required for silent renewal — without these, Claude prompts for re-login every hour):**
+
+1. **API** (`https://direct-satyr-14.hasura.app/v1/graphql`) → Settings → enable **"Allow Offline Access"**. Without this, Auth0 silently drops the `offline_access` scope, returns no refresh token, and the server degrades to access-token-only (today's hourly re-auth behavior) — so this can be flipped on before or after deploying the code.
+2. **Application** → Settings → Advanced Settings → Grant Types → ensure **Refresh Token** is checked.
+3. **Application** → Refresh Token Rotation/Expiration: rotation on or off both work (the server re-wraps whatever token Auth0 returns). If rotation is on, set a reuse interval of ~10–30 seconds to tolerate request races. Set idle/absolute lifetimes ≥ 30 days (the server's refresh-token TTL), or accept that Auth0 expiry forces a re-login first — either way the failure mode is a clean `invalid_grant` and Claude re-runs the login flow.
 
 ---
 
@@ -146,6 +152,7 @@ HASURA_GRAPHQL_URL=https://direct-satyr-14.hasura.app/v1/graphql
 HASURA_GRAPHQL_JWT_SECRET={"type":"HS256","key":"<secret>"}
 AUTH0_AUDIENCE=https://direct-satyr-14.hasura.app/v1/graphql
 PORT=3032
+REFRESH_TOKEN_TTL=30d   # optional; lifetime of issued refresh tokens (jsonwebtoken duration format)
 ```
 
 Reuses the JWT secret already in the cluster's secret store. No admin secret. No user credentials. The user's JWT comes from Claude.ai's session on each request and is used for both JWT validation and Hasura calls.
@@ -183,7 +190,7 @@ Claude.ai detects the MCP server requires OAuth (via the `/.well-known/oauth-pro
 
 ### Every subsequent use
 
-Claude.ai presents the stored JWT on each tool call. The MCP server validates it and calls Hasura. When the JWT expires, Claude.ai re-auths with Auth0 transparently (or prompts you to re-authorize, depending on the session length).
+Claude.ai presents the stored JWT on each tool call. The MCP server validates it and calls Hasura. When the 1-hour access token expires, the server's 401 carries a `WWW-Authenticate` header pointing at the OAuth metadata, and Claude.ai silently exchanges its refresh token at `/token` (`grant_type=refresh_token`) for a fresh access token — the server renews the upstream Auth0 token in the same exchange and hands back a re-wrapped refresh token. No login prompt. A full interactive re-authorization is only needed if the refresh token itself expires (default 30 days idle), the Auth0 grant is revoked, or Auth0's refresh-token lifetime is exceeded.
 
 ### Using it in Claude
 

--- a/mcp-server/src/index.test.ts
+++ b/mcp-server/src/index.test.ts
@@ -5,7 +5,7 @@ import { http, HttpResponse } from "msw";
 import { sign, decode } from "jsonwebtoken";
 import { app, extractBearerToken } from "./index.js";
 import { generateCodeChallenge, generateRandom, storePendingAuthorization, storePendingCode } from "./oauth.js";
-import { issueAccessToken } from "./token.js";
+import { issueAccessToken, issueRefreshToken, validateRefreshToken } from "./token.js";
 
 const SECRET = "test-secret-key";
 const AUDIENCE = "https://direct-satyr-14.hasura.app/v1/graphql";
@@ -21,9 +21,22 @@ function makeIdToken(sub = "auth0|user-123") {
 }
 
 const mswServer = setupServer(
-  http.post(`https://${AUTH0_DOMAIN}/oauth/token`, () =>
-    HttpResponse.json({ id_token: makeIdToken(), access_token: "opaque-at", token_type: "Bearer" })
-  ),
+  http.post(`https://${AUTH0_DOMAIN}/oauth/token`, async ({ request }) => {
+    const body = (await request.json()) as { grant_type?: string };
+    if (body.grant_type === "refresh_token") {
+      return HttpResponse.json({
+        access_token: "refreshed-at",
+        refresh_token: "rotated-a0-rt",
+        token_type: "Bearer",
+      });
+    }
+    return HttpResponse.json({
+      id_token: makeIdToken(),
+      access_token: "opaque-at",
+      refresh_token: "a0-rt",
+      token_type: "Bearer",
+    });
+  }),
   http.post(AUDIENCE, () => HttpResponse.json({ data: {} }))
 );
 
@@ -87,6 +100,12 @@ describe("GET /.well-known/oauth-authorization-server", () => {
     expect(res.body.authorization_endpoint).toMatch(/\/mcp\/authorize$/);
     expect(res.body.code_challenge_methods_supported).toContain("S256");
   });
+
+  it("advertises the refresh_token grant", async () => {
+    const res = await supertest(app).get("/.well-known/oauth-authorization-server");
+    expect(res.body.grant_types_supported).toContain("authorization_code");
+    expect(res.body.grant_types_supported).toContain("refresh_token");
+  });
 });
 
 // ─── GET /mcp/authorize ───────────────────────────────────────────────────────
@@ -133,6 +152,15 @@ describe("GET /mcp/authorize", () => {
     // Our state (not the client's state)
     expect(url.searchParams.get("state")).not.toBe("client-state");
     expect(url.searchParams.get("audience")).toBe(AUDIENCE);
+  });
+
+  it("requests offline_access from Auth0 so a refresh token is issued", async () => {
+    const res = await supertest(app).get(
+      "/mcp/authorize?response_type=code&client_id=claude&redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback&code_challenge=abc&code_challenge_method=S256&state=s"
+    );
+    expect(res.status).toBe(302);
+    const url = new URL(res.headers.location as string);
+    expect(url.searchParams.get("scope")).toContain("offline_access");
   });
 });
 
@@ -322,6 +350,156 @@ describe("POST /mcp/token", () => {
     expect(res.status).toBe(200);
     expect(res.body.access_token).toBe(expectedToken);
   });
+
+  it("omits refresh_token when the pending code has none (no offline access)", async () => {
+    const verifier = generateRandom();
+    const code = generateRandom();
+    storePendingCode(code, {
+      accessToken: issueAccessToken("auth0|user-123"),
+      codeChallenge: generateCodeChallenge(verifier),
+    });
+
+    const res = await supertest(app)
+      .post("/mcp/token")
+      .send({ grant_type: "authorization_code", code, code_verifier: verifier });
+    expect(res.status).toBe(200);
+    expect(res.body.refresh_token).toBeUndefined();
+  });
+});
+
+// ─── POST /mcp/token (grant_type=refresh_token) ──────────────────────────────
+
+describe("POST /mcp/token with grant_type=refresh_token", () => {
+  const refreshBody = (refresh_token: string) => ({ grant_type: "refresh_token", refresh_token });
+
+  it("issues a new access token carrying the refreshed Auth0 token", async () => {
+    const refreshToken = issueRefreshToken("auth0|user-123", "a0-rt");
+    const res = await supertest(app).post("/mcp/token").send(refreshBody(refreshToken));
+    expect(res.status).toBe(200);
+    expect(res.body.token_type).toBe("Bearer");
+    expect(res.body.expires_in).toBe(3600);
+    const claims = decode(res.body.access_token as string) as { sub?: string; a0t?: string };
+    expect(claims.sub).toBe("auth0|user-123");
+    expect(claims.a0t).toBe("refreshed-at");
+  });
+
+  it("returns a re-wrapped refresh token containing the rotated Auth0 refresh token", async () => {
+    const refreshToken = issueRefreshToken("auth0|user-123", "a0-rt");
+    const res = await supertest(app).post("/mcp/token").send(refreshBody(refreshToken));
+    expect(res.status).toBe(200);
+    const rewrapped = validateRefreshToken(res.body.refresh_token as string);
+    expect(rewrapped.sub).toBe("auth0|user-123");
+    // The msw handler rotates: the new wrapper must hold the rotated token
+    expect(rewrapped.auth0RefreshToken).toBe("rotated-a0-rt");
+  });
+
+  it("sends the decrypted Auth0 refresh token to Auth0", async () => {
+    let auth0Body: Record<string, unknown> = {};
+    mswServer.use(
+      http.post(`https://${AUTH0_DOMAIN}/oauth/token`, async ({ request }) => {
+        auth0Body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ access_token: "refreshed-at" });
+      })
+    );
+
+    const refreshToken = issueRefreshToken("auth0|user-123", "original-a0-rt");
+    const res = await supertest(app).post("/mcp/token").send(refreshBody(refreshToken));
+    expect(res.status).toBe(200);
+    expect(auth0Body.grant_type).toBe("refresh_token");
+    expect(auth0Body.refresh_token).toBe("original-a0-rt");
+  });
+
+  it("re-wraps the original Auth0 refresh token when Auth0 does not rotate", async () => {
+    mswServer.use(
+      http.post(`https://${AUTH0_DOMAIN}/oauth/token`, () =>
+        HttpResponse.json({ access_token: "refreshed-at" })
+      )
+    );
+
+    const refreshToken = issueRefreshToken("auth0|user-123", "stable-a0-rt");
+    const res = await supertest(app).post("/mcp/token").send(refreshBody(refreshToken));
+    expect(res.status).toBe(200);
+    expect(validateRefreshToken(res.body.refresh_token as string).auth0RefreshToken).toBe("stable-a0-rt");
+  });
+
+  it("returns invalid_grant for a garbage refresh token", async () => {
+    const res = await supertest(app).post("/mcp/token").send(refreshBody("not-a-jwt"));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_grant");
+  });
+
+  it("returns invalid_grant when the refresh token is missing", async () => {
+    const res = await supertest(app).post("/mcp/token").send({ grant_type: "refresh_token" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_grant");
+  });
+
+  it("returns invalid_grant when an access token is passed as a refresh token", async () => {
+    const res = await supertest(app)
+      .post("/mcp/token")
+      .send(refreshBody(issueAccessToken("auth0|user-123", "a0-at")));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_grant");
+  });
+
+  it("returns invalid_grant when Auth0 rejects the refresh token", async () => {
+    mswServer.use(
+      http.post(`https://${AUTH0_DOMAIN}/oauth/token`, () =>
+        HttpResponse.json({ error: "invalid_grant" }, { status: 403 })
+      )
+    );
+
+    const refreshToken = issueRefreshToken("auth0|user-123", "revoked-a0-rt");
+    const res = await supertest(app).post("/mcp/token").send(refreshBody(refreshToken));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_grant");
+  });
+
+  it("returns server_error when Auth0 is down, so the client keeps its refresh token", async () => {
+    mswServer.use(
+      http.post(`https://${AUTH0_DOMAIN}/oauth/token`, () => HttpResponse.json({}, { status: 500 }))
+    );
+
+    const refreshToken = issueRefreshToken("auth0|user-123", "a0-rt");
+    const res = await supertest(app).post("/mcp/token").send(refreshBody(refreshToken));
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("server_error");
+  });
+
+  it("returns server_error when the Auth0 request fails at the network level", async () => {
+    mswServer.use(
+      http.post(`https://${AUTH0_DOMAIN}/oauth/token`, () => HttpResponse.error())
+    );
+
+    const refreshToken = issueRefreshToken("auth0|user-123", "a0-rt");
+    const res = await supertest(app).post("/mcp/token").send(refreshBody(refreshToken));
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("server_error");
+  });
+
+  it("returns server_error when Auth0 responds with malformed JSON", async () => {
+    mswServer.use(
+      http.post(`https://${AUTH0_DOMAIN}/oauth/token`, () =>
+        new HttpResponse("not-json", { status: 200, headers: { "Content-Type": "application/json" } })
+      )
+    );
+
+    const refreshToken = issueRefreshToken("auth0|user-123", "a0-rt");
+    const res = await supertest(app).post("/mcp/token").send(refreshBody(refreshToken));
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("server_error");
+  });
+
+  it("returns server_error when Auth0 responds without an access_token", async () => {
+    mswServer.use(
+      http.post(`https://${AUTH0_DOMAIN}/oauth/token`, () => HttpResponse.json({}))
+    );
+
+    const refreshToken = issueRefreshToken("auth0|user-123", "a0-rt");
+    const res = await supertest(app).post("/mcp/token").send(refreshBody(refreshToken));
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("server_error");
+  });
 });
 
 // ─── Full OAuth flow ──────────────────────────────────────────────────────────
@@ -344,7 +522,7 @@ describe("full OAuth flow (authorize → callback → token → mcp)", () => {
       .send(`grant_type=authorization_code&code=${ourCode}&code_verifier=${verifier}`)
       .set("Content-Type", "application/x-www-form-urlencoded");
     expect(tokenRes.status).toBe(200);
-    return tokenRes.body as { access_token: string };
+    return tokenRes.body as { access_token: string; refresh_token?: string };
   }
 
   it("results in a working MCP Bearer token", async () => {
@@ -375,6 +553,43 @@ describe("full OAuth flow (authorize → callback → token → mcp)", () => {
     const claims = decode(access_token) as { a0t?: string };
     expect(claims?.a0t).toBe("opaque-at");
   });
+
+  it("returns a refresh token that silently renews the access token", async () => {
+    const { refresh_token } = await runFullOAuthFlow();
+    expect(refresh_token).toBeTruthy();
+    expect(validateRefreshToken(refresh_token!).auth0RefreshToken).toBe("a0-rt");
+
+    // Simulate Claude renewing after the 1h access token expires
+    const refreshRes = await supertest(app)
+      .post("/mcp/token")
+      .send(`grant_type=refresh_token&refresh_token=${refresh_token}`)
+      .set("Content-Type", "application/x-www-form-urlencoded");
+    expect(refreshRes.status).toBe(200);
+
+    const mcpRes = await supertest(app)
+      .post("/mcp")
+      .set("Authorization", `Bearer ${refreshRes.body.access_token}`)
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "test", version: "1" } },
+      });
+    expect(mcpRes.status).toBe(200);
+  });
+
+  it("omits the refresh token when Auth0 does not grant offline access", async () => {
+    mswServer.use(
+      http.post(`https://${AUTH0_DOMAIN}/oauth/token`, () =>
+        HttpResponse.json({ id_token: makeIdToken(), access_token: "opaque-at" })
+      )
+    );
+
+    const { access_token, refresh_token } = await runFullOAuthFlow();
+    expect(access_token).toBeTruthy();
+    expect(refresh_token).toBeUndefined();
+  });
 });
 
 // ─── POST /mcp auth ───────────────────────────────────────────────────────────
@@ -384,6 +599,9 @@ describe("POST /mcp", () => {
     const res = await supertest(app).post("/mcp").send({});
     expect(res.status).toBe(401);
     expect(res.body.error).toMatch(/Missing/);
+    expect(res.headers["www-authenticate"]).toMatch(
+      /^Bearer resource_metadata=".*\/\.well-known\/oauth-protected-resource"$/
+    );
   });
 
   it("returns 401 when Authorization is not a Bearer token", async () => {
@@ -395,6 +613,15 @@ describe("POST /mcp", () => {
     const res = await supertest(app).post("/mcp").set("Authorization", "Bearer not-a-valid-jwt").send({});
     expect(res.status).toBe(401);
     expect(res.body.error).toMatch(/Invalid/);
+    expect(res.headers["www-authenticate"]).toContain('error="invalid_token"');
+    expect(res.headers["www-authenticate"]).toContain("/.well-known/oauth-protected-resource");
+  });
+
+  it("returns 401 with WWW-Authenticate when the JWT is expired", async () => {
+    const expired = sign({ sub: "user-123" }, SECRET, { audience: AUDIENCE, expiresIn: -60 });
+    const res = await supertest(app).post("/mcp").set("Authorization", `Bearer ${expired}`).send({});
+    expect(res.status).toBe(401);
+    expect(res.headers["www-authenticate"]).toContain('error="invalid_token"');
   });
 
   it("passes a valid token through to the MCP transport", async () => {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -14,7 +14,7 @@ import {
   storePendingCode,
   consumePendingCode,
 } from "./oauth.js";
-import { issueAccessToken } from "./token.js";
+import { issueAccessToken, issueRefreshToken, validateRefreshToken } from "./token.js";
 
 const PORT = parseInt(process.env.PORT ?? "3032", 10);
 const SERVER_URL = process.env.MCP_SERVER_URL ?? `http://localhost:${PORT}/mcp`;
@@ -56,7 +56,7 @@ app.get("/.well-known/oauth-authorization-server", (_req, res) => {
     authorization_endpoint: AUTHORIZATION_ENDPOINT,
     token_endpoint: TOKEN_ENDPOINT,
     response_types_supported: ["code"],
-    grant_types_supported: ["authorization_code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
   });
 });
@@ -89,7 +89,9 @@ app.get(new URL(AUTHORIZATION_ENDPOINT).pathname, (req, res) => {
     redirect_uri: CALLBACK_ENDPOINT,
     state: ourState,
     audience: AUTH0_AUDIENCE,
-    scope: "openid profile email",
+    // offline_access asks Auth0 for a refresh token (requires "Allow Offline
+    // Access" on the API; silently ignored otherwise).
+    scope: "openid profile email offline_access",
   });
 
   res.redirect(`https://${AUTH0_DOMAIN}/authorize?${params.toString()}`);
@@ -116,6 +118,7 @@ app.get(new URL(CALLBACK_ENDPOINT).pathname, async (req, res) => {
 
   let sub: string;
   let auth0AccessToken = "";
+  let auth0RefreshToken = "";
   try {
     const tokenRes = await fetch(`https://${AUTH0_DOMAIN}/oauth/token`, {
       method: "POST",
@@ -131,10 +134,15 @@ app.get(new URL(CALLBACK_ENDPOINT).pathname, async (req, res) => {
 
     if (!tokenRes.ok) throw new Error(`Auth0 token exchange failed: ${tokenRes.status}`);
 
-    const tokenData = (await tokenRes.json()) as { id_token?: string; access_token?: string };
+    const tokenData = (await tokenRes.json()) as {
+      id_token?: string;
+      access_token?: string;
+      refresh_token?: string;
+    };
     if (!tokenData.id_token) throw new Error("No id_token in Auth0 response");
 
     auth0AccessToken = tokenData.access_token ?? "";
+    auth0RefreshToken = tokenData.refresh_token ?? "";
 
     // Decode without re-verifying — we received this directly from Auth0 over HTTPS
     const decoded = jwt.decode(tokenData.id_token) as { sub?: string } | null;
@@ -149,10 +157,11 @@ app.get(new URL(CALLBACK_ENDPOINT).pathname, async (req, res) => {
   }
 
   const accessToken = issueAccessToken(sub, auth0AccessToken);
+  const refreshToken = auth0RefreshToken ? issueRefreshToken(sub, auth0RefreshToken) : undefined;
   const ourCode = generateRandom();
-  storePendingCode(ourCode, { accessToken, codeChallenge: pending.clientCodeChallenge });
+  storePendingCode(ourCode, { accessToken, refreshToken, codeChallenge: pending.clientCodeChallenge });
 
-  logger.info("callback: issued code", { sub });
+  logger.info("callback: issued code", { sub, hasRefreshToken: Boolean(refreshToken) });
 
   const p = new URLSearchParams({ code: ourCode });
   if (pending.clientState) p.set("state", pending.clientState);
@@ -160,8 +169,14 @@ app.get(new URL(CALLBACK_ENDPOINT).pathname, async (req, res) => {
 });
 
 // Step 3: Claude.ai exchanges our code for our access token, proving they hold the PKCE verifier.
-app.post(new URL(TOKEN_ENDPOINT).pathname, (req, res) => {
-  const { code, code_verifier, grant_type } = req.body as Record<string, string>;
+// Also handles grant_type=refresh_token so the client can renew silently.
+app.post(new URL(TOKEN_ENDPOINT).pathname, async (req, res) => {
+  const { code, code_verifier, grant_type, refresh_token } = req.body as Record<string, string>;
+
+  if (grant_type === "refresh_token") {
+    await handleRefreshGrant(refresh_token, res);
+    return;
+  }
 
   if (grant_type !== "authorization_code") {
     res.status(400).json({ error: "unsupported_grant_type" });
@@ -182,8 +197,80 @@ app.post(new URL(TOKEN_ENDPOINT).pathname, (req, res) => {
   }
 
   logger.info("token: access token issued");
-  res.json({ access_token: pending.accessToken, token_type: "Bearer", expires_in: 3600 });
+  res.json({
+    access_token: pending.accessToken,
+    token_type: "Bearer",
+    expires_in: 3600,
+    ...(pending.refreshToken ? { refresh_token: pending.refreshToken } : {}),
+  });
 });
+
+async function handleRefreshGrant(refreshToken: string, res: express.Response): Promise<void> {
+  let sub: string;
+  let auth0RefreshToken: string;
+  try {
+    ({ sub, auth0RefreshToken } = validateRefreshToken(refreshToken));
+  } catch (e) {
+    logger.warn("token: invalid refresh token", { error: (e as Error).message });
+    res.status(400).json({ error: "invalid_grant" });
+    return;
+  }
+
+  let auth0Res: Response;
+  try {
+    auth0Res = await fetch(`https://${AUTH0_DOMAIN}/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        client_id: auth0ClientId(),
+        client_secret: auth0ClientSecret(),
+        refresh_token: auth0RefreshToken,
+      }),
+    });
+  } catch (e) {
+    logger.error("token: auth0 refresh request failed", { error: (e as Error).message });
+    res.status(500).json({ error: "server_error" });
+    return;
+  }
+
+  // 4xx means the Auth0 refresh token is revoked/expired/reused — the client
+  // must re-authorize. 5xx is transient: the client keeps its token and retries.
+  if (!auth0Res.ok) {
+    if (auth0Res.status >= 400 && auth0Res.status < 500) {
+      logger.warn("token: auth0 rejected refresh token", { status: auth0Res.status, sub });
+      res.status(400).json({ error: "invalid_grant" });
+    } else {
+      logger.error("token: auth0 refresh error", { status: auth0Res.status });
+      res.status(500).json({ error: "server_error" });
+    }
+    return;
+  }
+
+  let data: { access_token?: string; refresh_token?: string };
+  try {
+    data = (await auth0Res.json()) as { access_token?: string; refresh_token?: string };
+  } catch (e) {
+    logger.error("token: malformed auth0 refresh response", { error: (e as Error).message });
+    res.status(500).json({ error: "server_error" });
+    return;
+  }
+  if (!data.access_token) {
+    logger.error("token: no access_token in auth0 refresh response");
+    res.status(500).json({ error: "server_error" });
+    return;
+  }
+
+  logger.info("token: refreshed access token", { sub });
+  res.json({
+    access_token: issueAccessToken(sub, data.access_token),
+    // Re-wrap whichever Auth0 refresh token is now current (rotated or not);
+    // the client replaces its stored refresh token with this one.
+    refresh_token: issueRefreshToken(sub, data.refresh_token ?? auth0RefreshToken),
+    token_type: "Bearer",
+    expires_in: 3600,
+  });
+}
 
 export function extractBearerToken(req: express.Request): string | null {
   const auth = req.headers.authorization;
@@ -194,9 +281,14 @@ export function extractBearerToken(req: express.Request): string | null {
 async function handleMcp(req: express.Request, res: express.Response): Promise<void> {
   logger.info("request", { method: req.method, path: req.path });
 
+  // RFC 9728: point the client at our protected-resource metadata so it can
+  // re-run OAuth discovery instead of failing hard on an expired token.
+  const resourceMetadata = `resource_metadata="${BASE_URL}/.well-known/oauth-protected-resource"`;
+
   const token = extractBearerToken(req);
   if (!token) {
     logger.warn("auth rejected: missing token", { method: req.method, path: req.path });
+    res.set("WWW-Authenticate", `Bearer ${resourceMetadata}`);
     res.status(401).json({ error: "Missing Authorization header" });
     return;
   }
@@ -206,6 +298,7 @@ async function handleMcp(req: express.Request, res: express.Response): Promise<v
     decoded = validateJWT(token);
   } catch (e) {
     logger.warn("auth rejected: invalid token", { error: (e as Error).message });
+    res.set("WWW-Authenticate", `Bearer error="invalid_token", ${resourceMetadata}`);
     res.status(401).json({ error: "Invalid or expired token" });
     return;
   }

--- a/mcp-server/src/oauth.ts
+++ b/mcp-server/src/oauth.ts
@@ -10,6 +10,7 @@ interface PendingAuthorization {
 
 interface PendingCode {
   accessToken: string;
+  refreshToken?: string;
   codeChallenge: string;
   expiresAt: number;
 }

--- a/mcp-server/src/token.test.ts
+++ b/mcp-server/src/token.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { verify } from "jsonwebtoken";
-import { issueAccessToken } from "./token.js";
+import { verify, decode, sign } from "jsonwebtoken";
+import { issueAccessToken, issueRefreshToken, validateRefreshToken } from "./token.js";
+import { validateJWT } from "./auth.js";
 
 const SECRET = "test-secret-key";
 const AUDIENCE = "https://direct-satyr-14.hasura.app/v1/graphql";
@@ -68,3 +69,100 @@ describe("issueAccessToken", () => {
     expect(() => issueAccessToken("sub")).toThrow("HASURA_GRAPHQL_JWT_SECRET is not set");
   });
 });
+
+describe("issueRefreshToken / validateRefreshToken", () => {
+  beforeEach(() => {
+    process.env.HASURA_GRAPHQL_JWT_SECRET = JSON.stringify({ type: "HS256", key: SECRET });
+    process.env.AUTH0_AUDIENCE = AUDIENCE;
+  });
+
+  afterEach(() => {
+    delete process.env.HASURA_GRAPHQL_JWT_SECRET;
+    delete process.env.AUTH0_AUDIENCE;
+    delete process.env.REFRESH_TOKEN_TTL;
+  });
+
+  it("round-trips the sub and the Auth0 refresh token", () => {
+    const token = issueRefreshToken("auth0|user-123", "a0-refresh-secret");
+    const result = validateRefreshToken(token);
+    expect(result.sub).toBe("auth0|user-123");
+    expect(result.auth0RefreshToken).toBe("a0-refresh-secret");
+  });
+
+  it("does not expose the Auth0 refresh token in the JWT payload", () => {
+    const token = issueRefreshToken("auth0|user-123", "a0-refresh-secret");
+    const payload = decode(token) as { a0rt?: string };
+    expect(JSON.stringify(payload)).not.toContain("a0-refresh-secret");
+    expect(payload.a0rt).toBeTruthy();
+  });
+
+  it("does not carry Hasura claims, so it cannot act as an access token", () => {
+    const token = issueRefreshToken("auth0|user-123", "a0-refresh-secret");
+    const payload = decode(token) as Record<string, unknown>;
+    expect(payload["https://hasura.io/jwt/claims"]).toBeUndefined();
+    // validateJWT checks the Hasura audience, so the refresh token is rejected at /mcp
+    expect(() => validateJWT(token)).toThrow();
+  });
+
+  it("rejects an access token passed as a refresh token (audience mismatch)", () => {
+    const accessToken = issueAccessToken("auth0|user-123", "a0-at");
+    expect(() => validateRefreshToken(accessToken)).toThrow();
+  });
+
+  it("rejects a tampered a0rt ciphertext (GCM auth failure)", () => {
+    const token = issueRefreshToken("auth0|user-123", "a0-refresh-secret");
+    const { a0rt } = decode(token) as { a0rt: string };
+    const [iv, ciphertext, tag] = a0rt.split(".");
+    const flipped = Buffer.from(ciphertext, "base64url");
+    flipped[0] ^= 0xff;
+    const tamperedA0rt = `${iv}.${flipped.toString("base64url")}.${tag}`;
+    expect(() => validateRefreshToken(issueRefreshTokenWithA0rt(tamperedA0rt))).toThrow();
+  });
+
+  it("rejects a malformed a0rt claim", () => {
+    expect(() => validateRefreshToken(issueRefreshTokenWithA0rt("not-encrypted"))).toThrow();
+  });
+
+  it("rejects a refresh token missing sub or a0rt", () => {
+    const noA0rt = sign({ sub: "auth0|user-123" }, SECRET, {
+      algorithm: "HS256",
+      audience: "food-diary-mcp-refresh",
+      expiresIn: "30d",
+    });
+    expect(() => validateRefreshToken(noA0rt)).toThrow(/Malformed refresh token/);
+  });
+
+  it("rejects an expired refresh token", () => {
+    process.env.REFRESH_TOKEN_TTL = "-1s";
+    const token = issueRefreshToken("auth0|user-123", "a0-refresh-secret");
+    expect(() => validateRefreshToken(token)).toThrow(/expired/);
+  });
+
+  it("respects the REFRESH_TOKEN_TTL env var", () => {
+    process.env.REFRESH_TOKEN_TTL = "7d";
+    const token = issueRefreshToken("auth0|user-123", "a0-refresh-secret");
+    const payload = decode(token) as { iat: number; exp: number };
+    expect(payload.exp - payload.iat).toBe(7 * 24 * 60 * 60);
+  });
+
+  it("defaults to a 30 day lifetime", () => {
+    const token = issueRefreshToken("auth0|user-123", "a0-refresh-secret");
+    const payload = decode(token) as { iat: number; exp: number };
+    expect(payload.exp - payload.iat).toBe(30 * 24 * 60 * 60);
+  });
+
+  it("throws when HASURA_GRAPHQL_JWT_SECRET is not set", () => {
+    delete process.env.HASURA_GRAPHQL_JWT_SECRET;
+    expect(() => issueRefreshToken("sub", "rt")).toThrow("HASURA_GRAPHQL_JWT_SECRET is not set");
+  });
+});
+
+// Signs a refresh JWT whose a0rt claim is replaced with the given value,
+// keeping the signature valid so only decryption can fail.
+function issueRefreshTokenWithA0rt(a0rt: string): string {
+  return sign({ sub: "auth0|user-123", a0rt }, SECRET, {
+    algorithm: "HS256",
+    audience: "food-diary-mcp-refresh",
+    expiresIn: "30d",
+  });
+}

--- a/mcp-server/src/token.ts
+++ b/mcp-server/src/token.ts
@@ -1,10 +1,17 @@
 import jwt from "jsonwebtoken";
-import { createSecretKey } from "crypto";
+import { createSecretKey, createCipheriv, createDecipheriv, hkdfSync, randomBytes } from "crypto";
 
-export function issueAccessToken(sub: string, auth0AccessToken = ""): string {
+const REFRESH_AUDIENCE = "food-diary-mcp-refresh";
+
+function signingKey(): string {
   const secret = process.env.HASURA_GRAPHQL_JWT_SECRET;
   if (!secret) throw new Error("HASURA_GRAPHQL_JWT_SECRET is not set");
   const { key } = JSON.parse(secret) as { type: string; key: string };
+  return key;
+}
+
+export function issueAccessToken(sub: string, auth0AccessToken = ""): string {
+  const key = signingKey();
   const audience = process.env.AUTH0_AUDIENCE ?? "https://direct-satyr-14.hasura.app/v1/graphql";
   const issuer = process.env.MCP_SERVER_URL ?? "http://localhost:3032/mcp";
 
@@ -23,4 +30,54 @@ export function issueAccessToken(sub: string, auth0AccessToken = ""): string {
     createSecretKey(Buffer.from(key, "utf8")),
     { algorithm: "HS256", audience, issuer, expiresIn: "1h" }
   );
+}
+
+// Domain-separated AES-256-GCM key so the Auth0 refresh token inside our
+// refresh JWT is opaque to the client (JWT payloads are only base64).
+function encryptionKey(): Buffer {
+  return Buffer.from(
+    hkdfSync("sha256", Buffer.from(signingKey(), "utf8"), "", "food-diary-mcp-refresh-encryption", 32)
+  );
+}
+
+function encrypt(plaintext: string): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", encryptionKey(), iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${iv.toString("base64url")}.${ciphertext.toString("base64url")}.${tag.toString("base64url")}`;
+}
+
+function decrypt(payload: string): string {
+  const [iv, ciphertext, tag] = payload.split(".").map((p) => Buffer.from(p, "base64url"));
+  if (!iv || !ciphertext || !tag) throw new Error("Malformed encrypted payload");
+  const decipher = createDecipheriv("aes-256-gcm", encryptionKey(), iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+}
+
+export function issueRefreshToken(sub: string, auth0RefreshToken: string): string {
+  const issuer = process.env.MCP_SERVER_URL ?? "http://localhost:3032/mcp";
+  return jwt.sign(
+    { sub, a0rt: encrypt(auth0RefreshToken) },
+    createSecretKey(Buffer.from(signingKey(), "utf8")),
+    {
+      algorithm: "HS256",
+      // Distinct audience: validateJWT (Hasura audience) rejects this token
+      // at /mcp, so it can never be replayed as an access token.
+      audience: REFRESH_AUDIENCE,
+      issuer,
+      expiresIn: (process.env.REFRESH_TOKEN_TTL ?? "30d") as jwt.SignOptions["expiresIn"],
+    }
+  );
+}
+
+export function validateRefreshToken(token: string): { sub: string; auth0RefreshToken: string } {
+  const hmacKey = createSecretKey(Buffer.from(signingKey(), "utf8"));
+  const decoded = jwt.verify(token, hmacKey, {
+    algorithms: ["HS256"],
+    audience: REFRESH_AUDIENCE,
+  }) as { sub?: string; a0rt?: string };
+  if (!decoded.sub || !decoded.a0rt) throw new Error("Malformed refresh token");
+  return { sub: decoded.sub, auth0RefreshToken: decrypt(decoded.a0rt) };
 }


### PR DESCRIPTION
Claude had to manually reauthorize the connector every hour: the server
issued 1h access tokens with no refresh_token grant and never requested
offline_access from Auth0, so expiry always forced a full interactive
login.

- Request offline_access from Auth0 and capture its refresh token at
  /callback
- Issue a stateless refresh token (default 30d, REFRESH_TOKEN_TTL to
  override): a signed JWT carrying the Auth0 refresh token in an
  AES-256-GCM-encrypted a0rt claim (HKDF key from the Hasura secret),
  with a distinct audience so it can't be replayed as an access token;
  no server-side storage, so restarts don't invalidate it
- Handle grant_type=refresh_token at /token: renew the Auth0 token
  upstream, mint a fresh 1h access token, and return a re-wrapped
  refresh token (rotation-safe); Auth0 4xx maps to invalid_grant so
  clients know to fully re-auth, 5xx to server_error so they retry
- Advertise refresh_token in grant_types_supported
- Add RFC 9728 WWW-Authenticate headers to /mcp 401s
- Document the required Auth0 setup (Allow Offline Access, Refresh
  Token grant) in docs/mcp-connector.md

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WqsUk5B7WHb99tFZRk5Nna