### PR TITLE
Add pull-to-refresh to the diary entry list

### DIFF
--- a/web/src/DiaryList.test.tsx
+++ b/web/src/DiaryList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@solidjs/testing-library";
+import { render, screen, waitFor, fireEvent } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "./test-setup";
@@ -818,6 +818,70 @@ describe("DiaryList", () => {
     });
     expect(screen.queryByText("Older Meal")).toBeFalsy();
     expect(screen.queryByText(/Next Week/)).toBeFalsy();
+  });
+
+  it("should refetch entries when pulled to refresh", async () => {
+    let entriesRequests = 0;
+
+    server.use(
+      http.post("/api/v1/graphql", async ({ request }) => {
+        const body = (await request.json()) as { query?: string };
+        if (body.query?.includes("GetEntries")) {
+          entriesRequests += 1;
+          if (entriesRequests === 1) {
+            return HttpResponse.json({
+              data: { food_diary_diary_entry: [] },
+            });
+          }
+          return HttpResponse.json({
+            data: {
+              food_diary_diary_entry: [
+                {
+                  id: 1,
+                  consumed_at: new Date().toISOString(),
+                  servings: 1,
+                  calories: 95,
+                  nutrition_item: {
+                    id: 1,
+                    description: "Apple",
+                    calories: 95,
+                    protein_grams: 0.5,
+                    added_sugars_grams: 0,
+                    total_fat_grams: 0.3,
+                    dietary_fiber_grams: 2.4,
+                  },
+                  recipe: null,
+                },
+              ],
+            },
+          });
+        }
+        return HttpResponse.json({
+          data: {
+            current_week: { aggregate: { sum: { calories: 0 } } },
+            past_four_weeks: { aggregate: { sum: { calories: 0 } } },
+          },
+        });
+      }),
+    );
+
+    render(() => <DiaryList />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No entries this week.")).toBeTruthy();
+    });
+
+    // Simulate a pull-down gesture from the top of the page past the
+    // refresh threshold (finger movement is damped by half).
+    const container = screen.getByTestId("pull-to-refresh");
+    fireEvent.touchStart(container, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(container, { touches: [{ clientY: 200 }] });
+    fireEvent.touchEnd(container);
+
+    await waitFor(() => {
+      expect(screen.getByText("Apple")).toBeTruthy();
+    });
+    expect(entriesRequests).toBe(2);
   });
 
   it("should sort entries by time within a day", async () => {

--- a/web/src/DiaryList.tsx
+++ b/web/src/DiaryList.tsx
@@ -12,6 +12,7 @@ import { useAuth } from "./Auth0";
 import { parseAndFormatTime, parseAndFormatDay, pluralize } from "./Util";
 import DateBadge from "./DateBadge";
 import ButtonLink from "./ButtonLink";
+import PullToRefresh from "./PullToRefresh";
 import CircleProgress from "./CircleProgress";
 import { useNutritionTargets } from "./NutritionTargets";
 import {
@@ -93,7 +94,7 @@ const DiaryList: Component = () => {
     startOfDay(subDays(now, PAGE_DAYS - 1 + page * PAGE_DAYS)).toISOString();
 
   const [page, setPage] = createSignal(0);
-  const [getEntriesQuery, { mutate }] = createAuthorizedResource(
+  const [getEntriesQuery, { mutate, refetch }] = createAuthorizedResource(
     page,
     (token: string, pageNumber: number) =>
       fetchEntries(
@@ -108,9 +109,10 @@ const DiaryList: Component = () => {
   const sevenDaysAgoStart = startOfDay(subDays(now, 7)).toISOString();
   const fourWeeksAgoStart = startOfDay(subWeeks(now, 4)).toISOString();
 
-  const [weeklyStatsQuery] = createAuthorizedResource((token: string) =>
-    fetchWeeklyStats(token, sevenDaysAgoStart, todayStart, fourWeeksAgoStart),
-  );
+  const [weeklyStatsQuery, { refetch: refetchWeeklyStats }] =
+    createAuthorizedResource((token: string) =>
+      fetchWeeklyStats(token, sevenDaysAgoStart, todayStart, fourWeeksAgoStart),
+    );
 
   // Rolling 7-day window for consistent daily average
   const currentWeekDays = 7;
@@ -135,8 +137,10 @@ const DiaryList: Component = () => {
     );
   };
 
+  const refresh = () => Promise.all([refetch(), refetchWeeklyStats()]);
+
   return (
-    <>
+    <PullToRefresh onRefresh={refresh}>
       <div class="flex space-x-4 mb-4">
         <ButtonLink href="/diary_entry/new">Add New Entry</ButtonLink>
         <ButtonLink href="/nutrition_item/new">Add Item</ButtonLink>
@@ -311,7 +315,7 @@ const DiaryList: Component = () => {
           </button>
         </Show>
       </div>
-    </>
+    </PullToRefresh>
   );
 };
 

--- a/web/src/PullToRefresh.test.tsx
+++ b/web/src/PullToRefresh.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
+import PullToRefresh, { PULL_THRESHOLD } from "./PullToRefresh";
+
+function pull(
+  element: Element,
+  distance: number,
+  { release = true }: { release?: boolean } = {},
+) {
+  // Finger movement is damped by the component, so move twice as far as the
+  // indicator distance we want.
+  fireEvent.touchStart(element, { touches: [{ clientY: 0 }] });
+  fireEvent.touchMove(element, { touches: [{ clientY: distance * 2 }] });
+  if (release) {
+    fireEvent.touchEnd(element);
+  }
+}
+
+describe("PullToRefresh", () => {
+  beforeEach(() => {
+    document.documentElement.scrollTop = 0;
+  });
+
+  it("renders its children", () => {
+    render(() => (
+      <PullToRefresh onRefresh={() => Promise.resolve()}>
+        <p>Diary content</p>
+      </PullToRefresh>
+    ));
+
+    expect(screen.getByText("Diary content")).toBeTruthy();
+  });
+
+  it("calls onRefresh when pulled past the threshold", async () => {
+    const onRefresh = vi.fn(() => Promise.resolve());
+    render(() => (
+      <PullToRefresh onRefresh={onRefresh}>
+        <p>Diary content</p>
+      </PullToRefresh>
+    ));
+
+    pull(screen.getByTestId("pull-to-refresh"), PULL_THRESHOLD + 10);
+
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not call onRefresh when released before the threshold", () => {
+    const onRefresh = vi.fn(() => Promise.resolve());
+    render(() => (
+      <PullToRefresh onRefresh={onRefresh}>
+        <p>Diary content</p>
+      </PullToRefresh>
+    ));
+
+    pull(screen.getByTestId("pull-to-refresh"), PULL_THRESHOLD - 10);
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("does not call onRefresh when the page is scrolled down", () => {
+    const onRefresh = vi.fn(() => Promise.resolve());
+    render(() => (
+      <PullToRefresh onRefresh={onRefresh}>
+        <p>Diary content</p>
+      </PullToRefresh>
+    ));
+
+    // jsdom has no layout, so shadow the scrollingElement getter to simulate
+    // a scrolled page, then remove the shadow to restore the real getter.
+    Object.defineProperty(document, "scrollingElement", {
+      value: { scrollTop: 200 } as Element,
+      configurable: true,
+    });
+    try {
+      pull(screen.getByTestId("pull-to-refresh"), PULL_THRESHOLD + 10);
+    } finally {
+      delete (document as { scrollingElement?: Element }).scrollingElement;
+    }
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("shows a spinner while refreshing and hides it when done", async () => {
+    let resolveRefresh: () => void = () => {};
+    const onRefresh = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+    render(() => (
+      <PullToRefresh onRefresh={onRefresh}>
+        <p>Diary content</p>
+      </PullToRefresh>
+    ));
+
+    pull(screen.getByTestId("pull-to-refresh"), PULL_THRESHOLD + 10);
+
+    await waitFor(() => expect(screen.getByRole("status")).toBeTruthy());
+
+    resolveRefresh();
+    await waitFor(() => expect(screen.queryByRole("status")).toBeNull());
+  });
+
+  it("ignores pulls that start while a refresh is in flight", async () => {
+    const onRefresh = vi.fn(() => new Promise<void>(() => {}));
+    render(() => (
+      <PullToRefresh onRefresh={onRefresh}>
+        <p>Diary content</p>
+      </PullToRefresh>
+    ));
+    const container = screen.getByTestId("pull-to-refresh");
+
+    pull(container, PULL_THRESHOLD + 10);
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+
+    pull(container, PULL_THRESHOLD + 10);
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the pull when the finger moves back above the start", () => {
+    const onRefresh = vi.fn(() => Promise.resolve());
+    render(() => (
+      <PullToRefresh onRefresh={onRefresh}>
+        <p>Diary content</p>
+      </PullToRefresh>
+    ));
+    const container = screen.getByTestId("pull-to-refresh");
+
+    fireEvent.touchStart(container, { touches: [{ clientY: 100 }] });
+    fireEvent.touchMove(container, {
+      touches: [{ clientY: 100 + PULL_THRESHOLD * 2 }],
+    });
+    fireEvent.touchMove(container, { touches: [{ clientY: 50 }] });
+    fireEvent.touchEnd(container);
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/PullToRefresh.tsx
+++ b/web/src/PullToRefresh.tsx
@@ -1,0 +1,120 @@
+import type { Component, ParentProps } from "solid-js";
+import { Show, createSignal, onCleanup, onMount } from "solid-js";
+
+// Distance (in px, after resistance) the user must pull before releasing
+// triggers a refresh.
+export const PULL_THRESHOLD = 60;
+// Cap on how far the indicator can be pulled down.
+const MAX_PULL = 100;
+// Finger movement is damped by this factor so the pull feels elastic.
+const RESISTANCE = 0.5;
+
+type PullToRefreshProps = ParentProps<{
+  onRefresh: () => Promise<unknown>;
+}>;
+
+const PullToRefresh: Component<PullToRefreshProps> = (
+  props: PullToRefreshProps,
+) => {
+  const [pullDistance, setPullDistance] = createSignal(0);
+  const [pulling, setPulling] = createSignal(false);
+  const [refreshing, setRefreshing] = createSignal(false);
+  let startY: number | null = null;
+  let container: HTMLDivElement | undefined;
+
+  const atTop = () => (document.scrollingElement?.scrollTop ?? 0) <= 0;
+
+  const onTouchStart = (event: TouchEvent) => {
+    if (refreshing() || !atTop()) return;
+    startY = event.touches[0].clientY;
+    setPulling(true);
+  };
+
+  const onTouchMove = (event: TouchEvent) => {
+    if (startY === null || refreshing()) return;
+    const delta = event.touches[0].clientY - startY;
+    if (delta <= 0 || !atTop()) {
+      setPullDistance(0);
+      return;
+    }
+    // Take over from native scrolling while the user is pulling down
+    // from the top of the page.
+    if (event.cancelable) event.preventDefault();
+    setPullDistance(Math.min(delta * RESISTANCE, MAX_PULL));
+  };
+
+  const onTouchEnd = () => {
+    if (startY === null) return;
+    startY = null;
+    setPulling(false);
+    if (pullDistance() < PULL_THRESHOLD) {
+      setPullDistance(0);
+      return;
+    }
+    setRefreshing(true);
+    setPullDistance(PULL_THRESHOLD);
+    void (async () => {
+      try {
+        await props.onRefresh();
+      } finally {
+        setRefreshing(false);
+        setPullDistance(0);
+      }
+    })();
+  };
+
+  onMount(() => {
+    const el = container;
+    if (!el) return;
+    // touchmove must be registered non-passive so preventDefault can stop
+    // the browser's native scroll/overscroll while pulling.
+    el.addEventListener("touchstart", onTouchStart, { passive: true });
+    el.addEventListener("touchmove", onTouchMove, { passive: false });
+    el.addEventListener("touchend", onTouchEnd);
+    el.addEventListener("touchcancel", onTouchEnd);
+    onCleanup(() => {
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchmove", onTouchMove);
+      el.removeEventListener("touchend", onTouchEnd);
+      el.removeEventListener("touchcancel", onTouchEnd);
+    });
+  });
+
+  return (
+    <div ref={container} data-testid="pull-to-refresh">
+      <div
+        class="flex items-end justify-center overflow-hidden"
+        aria-hidden={pullDistance() === 0}
+        style={{
+          height: `${pullDistance()}px`,
+          transition: pulling() ? "none" : "height 0.2s ease-out",
+        }}
+      >
+        <Show
+          when={refreshing()}
+          fallback={
+            <span
+              class="mb-2 text-slate-400 transition-transform"
+              style={{
+                transform: `rotate(${
+                  pullDistance() >= PULL_THRESHOLD ? 180 : 0
+                }deg)`,
+              }}
+            >
+              ↓
+            </span>
+          }
+        >
+          <span
+            role="status"
+            aria-label="Refreshing"
+            class="mb-2 h-6 w-6 animate-spin rounded-full border-2 border-slate-300 border-t-indigo-600"
+          />
+        </Show>
+      </div>
+      {props.children}
+    </div>
+  );
+};
+
+export default PullToRefresh;


### PR DESCRIPTION
Wrap the diary list in a new PullToRefresh component that tracks
touch gestures: pulling down from the top of the page past a
threshold refetches the diary entries and weekly stats, showing a
spinner until both requests settle. Short pulls, pulls while
scrolled down, and pulls during an in-flight refresh are ignored.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HbzrSe6VJ2bzJWV7Gp7cpn