### PR TITLE
Bump llama-cpp-2 to 0.1.151 for MiniCPM-V 4.6 projector support

### DIFF
--- a/nutrition-fact-labeller/Cargo.lock
+++ b/nutrition-fact-labeller/Cargo.lock
@@ -1475,9 +1475,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.146"
+version = "0.1.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b0f368c76cc0fe475e8257aeeec269e0d6569bd48b1f503efd0963fc3ee397"
+checksum = "36ead0925a19d754d5d13761ceb0f0fe49d36f8103c3596588ac1fb8911e5223"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -1489,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.146"
+version = "0.1.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b291e4bc2d10c43cd8dec16d49b6104cb3cb125f596ec380a753a5db1d965dd"
+checksum = "23c676b02f8f2bdd9d7df7bcca0bd176b27964440998e7aa31c6fe32552964d0"
 dependencies = [
  "bindgen",
  "cc",

--- a/nutrition-fact-labeller/Cargo.toml
+++ b/nutrition-fact-labeller/Cargo.toml
@@ -14,7 +14,7 @@ encoding_rs = "0.8"
 env_logger = "0.11.8"
 futures-util = "0.3.31"
 image = "0.25.7"
-llama-cpp-2 = { version = "0.1.146", features = ["mtmd"] }
+llama-cpp-2 = { version = "0.1.151", features = ["mtmd"] }
 log = "0.4.28"
 oar-ocr = { version = "0.2.2" }
 pretty_assertions = "1.4.1"

--- a/nutrition-fact-labeller/README.md
+++ b/nutrition-fact-labeller/README.md
@@ -58,6 +58,21 @@ VLM_MMPROJ_PATH=nutrition-fact-labeller/vlm-models/gemma-4-e2b/mmproj-F16.gguf
 
 If no VLM env vars are set, the service starts in OCR-only mode.
 
+### VLM Benchmark
+
+`src/bin/vlm_benchmark.rs` runs local llama.cpp VLM backends against `test_cases.csv` / `images/`
+and compares against the PaddleOCR baseline:
+
+```bash
+cargo run --release --bin vlm_benchmark -- \
+  --model /path/to/model.gguf \
+  --mmproj /path/to/mmproj.gguf \
+  --model-name "my-model" \
+  --threads 4
+```
+
+Past results are recorded in [`eval-results/`](eval-results/).
+
 ### Run
 
 ```bash

--- a/nutrition-fact-labeller/eval-results/2026-07-11-minicpm-v-4.6-q4_k_m.md
+++ b/nutrition-fact-labeller/eval-results/2026-07-11-minicpm-v-4.6-q4_k_m.md
@@ -1,0 +1,94 @@
+# VLM Backend Eval Report — MiniCPM-V 4.6
+
+**Date:** 2026-07-11
+**Model:** [openbmb/MiniCPM-V-4.6-gguf](https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf), `MiniCPM-V-4_6-Q4_K_M.gguf` + `mmproj-model-f16.gguf` (F16 vision projector)
+**Backend:** local llama.cpp (`LlavaBackend`, `src/vlm/llava.rs`), 4 CPU threads, no GPU
+**Harness:** `cargo run --release --bin vlm_benchmark`
+**Cases:** 33 (all of `test_cases.csv` / `images/`)
+**Runtime:** ~25 min total (~45s/image)
+
+## Result
+
+| Model | Pass | Fail | Score |
+|---|---|---|---|
+| PaddleOCR (baseline, OCR + regex) | 9 | 24 | 9/33 |
+| Gemma 4 E2B (local llama.cpp, per code comment in `llava.rs`) | 14 | 19 | 14/33 |
+| **MiniCPM-V-4.6-Q4_K_M (local llama.cpp)** | **0** | **33** | **0/33** |
+
+MiniCPM-V 4.6 scored 0/33 under the harness's strict comparison, which requires the model's
+JSON response to deserialize directly into the typed `ParsedNutritionFacts` struct (numeric
+fields, not strings) and then match the expected values exactly.
+
+## Root cause
+
+32 of 33 responses failed to deserialize at all. `NUTRITION_PROMPT` explicitly asks for
+`<number|null>` values, but MiniCPM-V 4.6 (this quant) consistently returned numeric fields as
+JSON strings, sometimes with embedded units or comparison operators, e.g.:
+
+```json
+{"servings_per_container": "8", "serving_size_grams": "30g", "calories": "110",
+ "total_fat_grams": "1.5", "dietary_fiber_g": "<1g", "protein_g": "3g"}
+```
+
+Occasionally a field name also came back with a stray leading space and different casing
+(`" Serving_size_grams"` instead of `"serving_size_grams"`), which would fail to populate that
+field even under a lenient parser.
+
+The one case that *did* deserialize cleanly (`IMG_5424_1200.png`) still failed the equality
+check because two of the eleven fields (`serving_size_grams`, `total_carbohydrates_g`) came back
+`null` despite being present on the label — the rest matched.
+
+## Exploratory lenient-parsing analysis
+
+To sanity-check whether the 0/33 score is purely a JSON-typing artifact or reflects genuinely
+wrong reads, the 32 failed responses were re-scored with an ad hoc script that:
+- coerces quoted numeric strings (`"30g"`, `"<1g"`) by extracting the first number found,
+- ignores field-name casing/whitespace,
+- allows a small absolute tolerance per field (0.6 for most fields, 5 for calories/sodium/cholesterol).
+
+This is **not** the production parsing path — just a script run against the raw log
+(`/tmp/.../lenient_analysis.py` from this session, not committed) to estimate an upper bound.
+
+Result: **10/33 (~30%)** would have passed under lenient numeric coercion — roughly on par with
+the PaddleOCR baseline (9/33) and below Gemma 4 E2B's reported 14/33. Several of the "near miss"
+cases involved `serving_size_grams` being read from a compound string like `"1 bar (30g)"`, where
+naive first-number extraction can itself introduce error, so 10/33 should be read as a rough
+upper bound, not a precise score.
+
+## Takeaway
+
+MiniCPM-V-4.6-Q4_K_M is not a good drop-in replacement for Gemma 4 E2B in this pipeline as
+currently prompted/parsed:
+
+1. It doesn't reliably follow the "numbers, not strings" instruction that the shared
+   `NUTRITION_PROMPT` and strict `serde_json` deserialization depend on.
+2. Even allowing for that formatting issue, its underlying nutrition-value extraction accuracy
+   looks roughly on par with the PaddleOCR baseline, not better.
+
+If MiniCPM-V 4.6 is worth pursuing further, the next steps would be:
+- Loosen `ParsedNutritionFacts` deserialization (or add a coercion step in `extract_json`) to
+  accept quoted/unit-suffixed numbers, then re-run this harness to get an apples-to-apples score
+  against Gemma 4 and PaddleOCR without the typing penalty.
+- Try prompt adjustments specific to MiniCPM (e.g., a one-shot example of correctly-typed JSON),
+  since its base instruction-following for this exact schema is weaker than Gemma 4's.
+
+## Infra note
+
+Running this eval required two small fixes, both committed on this branch:
+- `llama-cpp-2`/`llama-cpp-sys-2` bumped `0.1.146` → `0.1.151` — the older version's vendored
+  llama.cpp didn't recognize MiniCPM-V 4.6's `minicpmv4_6` mmproj projector type
+  (`unknown projector type: minicpmv4_6`).
+- `src/vlm/llava.rs` updated for that version's API changes (`MtmdContextParams` gained
+  `image_min_tokens`/`image_max_tokens`; `MtmdBitmap::from_file` gained a `placeholder` bool arg).
+
+## How to re-run
+
+```bash
+# From nutrition-fact-labeller/, after downloading the model + mmproj from
+# https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf :
+cargo run --release --bin vlm_benchmark -- \
+  --model /path/to/MiniCPM-V-4_6-Q4_K_M.gguf \
+  --mmproj /path/to/mmproj-model-f16.gguf \
+  --model-name "MiniCPM-V-4.6-Q4_K_M" \
+  --threads 4
+```

--- a/nutrition-fact-labeller/src/vlm/llava.rs
+++ b/nutrition-fact-labeller/src/vlm/llava.rs
@@ -61,6 +61,8 @@ impl VlmBackend for LlavaBackend {
             print_timings: false,
             n_threads: self.n_threads,
             media_marker: CString::new(marker.clone())?,
+            image_min_tokens: -1,
+            image_max_tokens: -1,
         };
         let mtmd_ctx = MtmdContext::init_from_file(
             self.mmproj_path.to_str().context("mmproj path not valid UTF-8")?,
@@ -80,7 +82,7 @@ impl VlmBackend for LlavaBackend {
 
         // Load image as bitmap
         let image_str = image_path.to_str().context("Image path not valid UTF-8")?;
-        let bitmap = MtmdBitmap::from_file(&mtmd_ctx, image_str)
+        let bitmap = MtmdBitmap::from_file(&mtmd_ctx, image_str, false)
             .context("Failed to load image bitmap")?;
 
         // Build prompt: image marker + instruction


### PR DESCRIPTION
0.1.146's vendored llama.cpp only recognizes the legacy "resampler"
minicpmv projector type; MiniCPM-V 4.6's mmproj GGUF uses the newer
"minicpmv4_6" projector type, which fails to load with
"unknown projector type: minicpmv4_6" on the old version.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015MKDDAQ3d9uTpECoUaox4r