### PR TITLE
VLM label parser eval: OCR-only resilient parsing + parametrized multi-model harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ graphql-engine/db_data/
 nutrition-fact-labeller/target/
 nutrition-fact-labeller/paddleocr-models/
 nutrition-fact-labeller/vlm-models/
+nutrition-fact-labeller/models/
 
 # llm-nutrition-api
 llm-nutrition-api/*.gguf

--- a/nutrition-fact-labeller/README.md
+++ b/nutrition-fact-labeller/README.md
@@ -65,6 +65,20 @@ against the PaddleOCR baseline. Past results are tracked in the living summary a
 [`eval-results/README.md`](eval-results/README.md) — check it before re-running an eval someone
 else already ran, and add to it after any new run.
 
+The easiest way to run either harness is via [`models.toml`](models.toml) — a manifest of every
+model this project tracks (HF repo, filenames, confirmed llama.cpp support, notes) — and the
+scripts that key off it:
+
+```bash
+./scripts/fetch-model.sh <key>            # download a model listed in models.toml
+./scripts/run-eval.sh <key> --smoke       # quick 2-image smoke test (does it load and run?)
+./scripts/run-eval.sh <key>               # full 33-image eval, both harnesses
+```
+
+To add a new model, add a `[models.<key>]` entry to `models.toml` and run the two commands above.
+
+Both binaries can also be run directly with explicit paths, if you're not using the manifest:
+
 `src/bin/vlm_benchmark.rs` — the VLM does the full image → structured JSON extraction itself:
 
 ```bash
@@ -72,7 +86,8 @@ cargo run --release --bin vlm_benchmark -- \
   --model /path/to/model.gguf \
   --mmproj /path/to/mmproj.gguf \
   --model-name "my-model" \
-  --threads 4
+  --threads 4 \
+  --limit 2  # optional: cap the number of images for a quick smoke test
 ```
 
 `src/bin/vlm_ocr_benchmark.rs` — the VLM is used purely as an OCR engine (image → transcribed
@@ -83,10 +98,9 @@ cargo run --release --bin vlm_ocr_benchmark -- \
   --model /path/to/model.gguf \
   --mmproj /path/to/mmproj.gguf \
   --model-name "my-model-ocr" \
-  --threads 4
+  --threads 4 \
+  --limit 2  # optional
 ```
-
-Past results are recorded in [`eval-results/`](eval-results/).
 
 ### Run
 

--- a/nutrition-fact-labeller/README.md
+++ b/nutrition-fact-labeller/README.md
@@ -61,7 +61,9 @@ If no VLM env vars are set, the service starts in OCR-only mode.
 ### VLM Benchmarks
 
 Two harnesses run local llama.cpp VLM backends against `test_cases.csv` / `images/` and compare
-against the PaddleOCR baseline. Past results are recorded in [`eval-results/`](eval-results/).
+against the PaddleOCR baseline. Past results are tracked in the living summary at
+[`eval-results/README.md`](eval-results/README.md) — check it before re-running an eval someone
+else already ran, and add to it after any new run.
 
 `src/bin/vlm_benchmark.rs` — the VLM does the full image → structured JSON extraction itself:
 

--- a/nutrition-fact-labeller/README.md
+++ b/nutrition-fact-labeller/README.md
@@ -58,16 +58,29 @@ VLM_MMPROJ_PATH=nutrition-fact-labeller/vlm-models/gemma-4-e2b/mmproj-F16.gguf
 
 If no VLM env vars are set, the service starts in OCR-only mode.
 
-### VLM Benchmark
+### VLM Benchmarks
 
-`src/bin/vlm_benchmark.rs` runs local llama.cpp VLM backends against `test_cases.csv` / `images/`
-and compares against the PaddleOCR baseline:
+Two harnesses run local llama.cpp VLM backends against `test_cases.csv` / `images/` and compare
+against the PaddleOCR baseline. Past results are recorded in [`eval-results/`](eval-results/).
+
+`src/bin/vlm_benchmark.rs` — the VLM does the full image → structured JSON extraction itself:
 
 ```bash
 cargo run --release --bin vlm_benchmark -- \
   --model /path/to/model.gguf \
   --mmproj /path/to/mmproj.gguf \
   --model-name "my-model" \
+  --threads 4
+```
+
+`src/bin/vlm_ocr_benchmark.rs` — the VLM is used purely as an OCR engine (image → transcribed
+text), and its output is fed through the same regex/spellcheck parser the PaddleOCR backend uses:
+
+```bash
+cargo run --release --bin vlm_ocr_benchmark -- \
+  --model /path/to/model.gguf \
+  --mmproj /path/to/mmproj.gguf \
+  --model-name "my-model-ocr" \
   --threads 4
 ```
 

--- a/nutrition-fact-labeller/eval-results/2026-07-11-minicpm-v-4.6-ocr-only.md
+++ b/nutrition-fact-labeller/eval-results/2026-07-11-minicpm-v-4.6-ocr-only.md
@@ -1,0 +1,102 @@
+# VLM-as-OCR-only Eval Report — MiniCPM-V 4.6
+
+**Date:** 2026-07-11
+**Model:** [openbmb/MiniCPM-V-4.6-gguf](https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf), `MiniCPM-V-4_6-Q4_K_M.gguf` + `mmproj-model-f16.gguf`
+**Backend:** local llama.cpp (`LlavaBackend::transcribe`, `src/vlm/llava.rs`), 4 CPU threads, no GPU
+**Harness:** `cargo run --release --bin vlm_ocr_benchmark`
+**Cases:** 33 (all of `test_cases.csv` / `images/`)
+**Runtime:** ~24 min total (~44s/image)
+
+This is a follow-up to [`2026-07-11-minicpm-v-4.6-q4_k_m.md`](2026-07-11-minicpm-v-4.6-q4_k_m.md), which
+had MiniCPM-V 4.6 do the full image→structured-JSON extraction itself. Here MiniCPM is used purely
+as an OCR engine — prompted to transcribe the label's text verbatim (`OCR_TRANSCRIBE_PROMPT`) — and
+its output is fed through the *same* line-oriented regex/spellcheck parser
+(`parsing::parse_facts_from_lines`) that the PaddleOCR backend already uses on its detected text
+regions. This isolates "can the VLM read the label" from "can the VLM emit well-typed JSON."
+
+## Result
+
+| Model | Pass | Fail | Score |
+|---|---|---|---|
+| PaddleOCR (baseline, OCR + regex) | 9 | 24 | 9/33 |
+| MiniCPM-V-4.6-Q4_K_M, full JSON extraction (previous report) | 0 | 33 | 0/33 |
+| **MiniCPM-V-4.6-Q4_K_M, OCR-only + regex parser** | **0** | **33** | **0/33** |
+
+Same headline number as the JSON approach, but for a very different — and more fixable — reason.
+
+## Diagnosis
+
+Unlike the JSON approach (which failed on type mismatches), MiniCPM's raw transcriptions were often
+close to correct. Re-scoring the 33 transcriptions by field-level mismatch count (not just
+exact-match pass/fail) shows two distinct failure modes:
+
+**1. Prompt non-adherence — collapsed transcription (11/33 cases).** Despite `OCR_TRANSCRIBE_PROMPT`
+explicitly asking for "one line of output per line of text," 11 of 33 images came back as a single
+run-on paragraph (or 2-3 giant lines) with no line breaks at all, e.g.:
+
+```
+IMG_5423_1200.png -> 1 line: "Nutrition Facts 12 servings per container Serving size 1 bar (36g)
+Calories 140 Total Fat 5g % Daily Value 6% Saturated Fat 1g 6% Trans Fat 0g Cholesterol 0mg 0% ..."
+```
+
+`parse_facts_from_lines` is fundamentally line-oriented (it looks for label/value adjacency across
+list entries), so these cases score 11/11 fields wrong — total failure, independent of read accuracy.
+
+**2. Parser/OCR-source mismatch — merged "Calories" line (10/33 cases missed by exactly one field).**
+For the other 22 images, MiniCPM preserved line breaks well and read values accurately. But 10 of
+those 22 missed *only* the `calories` field, because MiniCPM writes it as one line
+(`"Calories 110"`) while `parse_facts`'s calorie-matching logic requires "Calories" to be its own
+line adjacent to a purely-numeric line — a pattern written for PaddleOCR's per-detection-box output,
+not a VLM's natural line-per-printed-row transcription. E.g. `IMG_5437_1200.png` transcribed
+correctly on **all 11 fields except calories**:
+
+```
+got:      { ..., calories: None, ... }        (only mismatch)
+expected: { ..., calories: Some(110), ... }
+```
+
+A similar merged-line issue affects `added_sugars_g` in a few cases (`"Includes 3g Added Sugars"`
+transcribed as one phrase instead of split across lines).
+
+## Exploratory re-scoring (parser fix, no new inference)
+
+To estimate the ceiling of this approach, the 33 already-captured transcriptions were re-parsed
+offline (Python port of `parse_facts`, sanity-checked to reproduce 0/33 on the unmodified algorithm)
+with one small addition: also match a `calories` line followed directly by a number
+(`^calories\s+(\d+)`), not just "calories" as its own line. This is **not applied to the Rust code**
+— just a quick check of impact.
+
+Result: **6/33 pass outright** with that one change, and 8 more are down to a single remaining
+mismatch (mostly the analogous merged-line issue in `added_sugars_g`, or `servings_per_container`).
+The 11 collapsed-transcription cases are unaffected — they'd need a prompting fix (or a fallback
+that splits on sentence-like boundaries when no newlines come back), not a parser fix.
+
+## Takeaway
+
+Compared to the direct JSON-extraction approach, this is a more promising direction with a
+better-understood, narrower gap:
+
+- MiniCPM-V 4.6's OCR read accuracy is decent when it cooperates with the line-break instruction —
+  the blocking issue is mostly a data-shape mismatch between "one line per detected OCR box"
+  (what the parser was written against) and "one line per printed visual row" (what a VLM naturally
+  produces), not garbled reads.
+- ~1/3 of images ignore the "one line per line" instruction outright and return an unstructured
+  blob; this looks like a prompting problem for this specific quantization rather than a reading
+  problem, and would need a different mitigation (stronger prompt, few-shot line-break example, or
+  a parser that also tolerates run-on transcriptions).
+- If the `calories`-line-merge parser gap above were fixed for real (a small, low-risk change to
+  `parsing::parse_facts`, would also benefit the PaddleOCR path if it ever emits merged boxes), this
+  benchmark should be re-run to confirm — 6/33 is a rough upper bound from an unverified Python port,
+  not a Rust-verified number.
+
+## How to re-run
+
+```bash
+# From nutrition-fact-labeller/, with MiniCPM-V 4.6 weights downloaded per
+# https://huggingface.co/openbmb/MiniCPM-V-4.6-gguf :
+cargo run --release --bin vlm_ocr_benchmark -- \
+  --model /path/to/MiniCPM-V-4_6-Q4_K_M.gguf \
+  --mmproj /path/to/mmproj-model-f16.gguf \
+  --model-name "MiniCPM-V-4.6-Q4_K_M-ocr" \
+  --threads 4
+```

--- a/nutrition-fact-labeller/eval-results/2026-07-11-minicpm-v-4.6-ocr-only.md
+++ b/nutrition-fact-labeller/eval-results/2026-07-11-minicpm-v-4.6-ocr-only.md
@@ -20,9 +20,13 @@ regions. This isolates "can the VLM read the label" from "can the VLM emit well-
 |---|---|---|---|
 | PaddleOCR (baseline, OCR + regex) | 9 | 24 | 9/33 |
 | MiniCPM-V-4.6-Q4_K_M, full JSON extraction (previous report) | 0 | 33 | 0/33 |
-| **MiniCPM-V-4.6-Q4_K_M, OCR-only + regex parser** | **0** | **33** | **0/33** |
+| MiniCPM-V-4.6-Q4_K_M, OCR-only + regex parser (original parser) | 0 | 33 | 0/33 |
+| **MiniCPM-V-4.6-Q4_K_M, OCR-only + resilient parser (after fix below)** | **11** | **22** | **11/33 ▲ +2 vs. baseline** |
 
-Same headline number as the JSON approach, but for a very different — and more fixable — reason.
+The original parser scored the same 0/33 headline as the JSON approach, but for a very different —
+and, as it turned out, fixable — reason (see Diagnosis below). After the parser fix described in
+**Update** below, this became the first approach in this whole investigation to beat the PaddleOCR
+baseline, verified with a real re-run (not an estimate).
 
 ## Diagnosis
 
@@ -58,36 +62,49 @@ expected: { ..., calories: Some(110), ... }
 A similar merged-line issue affects `added_sugars_g` in a few cases (`"Includes 3g Added Sugars"`
 transcribed as one phrase instead of split across lines).
 
-## Exploratory re-scoring (parser fix, no new inference)
+## Update: resilient parser fix, verified re-run
 
-To estimate the ceiling of this approach, the 33 already-captured transcriptions were re-parsed
-offline (Python port of `parse_facts`, sanity-checked to reproduce 0/33 on the unmodified algorithm)
-with one small addition: also match a `calories` line followed directly by a number
-(`^calories\s+(\d+)`), not just "calories" as its own line. This is **not applied to the Rust code**
-— just a quick check of impact.
+Implemented in `parsing.rs` (`find_near` / `fill_gaps_from_blob`, see commit
+"Make parse_facts resilient to merged/run-on VLM transcriptions"). The original line-based
+`parse_facts` is untouched; a purely additive fallback pass now fires only for fields it left as
+`None`, scanning the *entire* transcription text and picking, for each label, the nearest number by
+character distance — regardless of whether the number appears before or after the label, and
+regardless of how many (or how few) lines the input arrived in. This directly targets both failure
+modes from the Diagnosis above: merged single-line label/value pairs, and fully collapsed
+run-on-paragraph transcriptions.
 
-Result: **6/33 pass outright** with that one change, and 8 more are down to a single remaining
-mismatch (mostly the analogous merged-line issue in `added_sugars_g`, or `servings_per_container`).
-The 11 collapsed-transcription cases are unaffected — they'd need a prompting fix (or a fallback
-that splits on sentence-like boundaries when no newlines come back), not a parser fix.
+Two real captured transcriptions (`IMG_5437_1200.png`, the merged-calories case, and
+`IMG_5423_1200.png`, the fully-collapsed case) were used as regression-test fixtures
+(`parsing::tests`) before re-running the full benchmark, to validate the fix without needing a new
+25-minute VLM run for every iteration.
+
+**Re-run result (real, Rust-verified): 11/33**, beating the PaddleOCR baseline (9/33) — up from 0/33
+with the original parser. Both fixture cases now pass end-to-end, including `IMG_5423_1200.png`
+(the fully-collapsed single-paragraph case).
+
+### Remaining gaps (22/33 still failing)
+
+- **7/22** are off by exactly one field — mostly `calories` or `added_sugars_g` still, on images
+  where those specific values fall outside the fallback's search window or get crowded out by a
+  nearer wrong number.
+- **~13/22** are off by 2–6 fields — generally images with partial line-break loss or bilingual/dense
+  layouts (e.g. `IMG_5447_1200.png`, `IMG_5464_1200.png`).
+- **2/22** (`IMG_5421_1200.png`, `IMG_5444_1200.png`) are still off by ~10 fields — these are the
+  hardest collapsed-transcription cases (one is the bilingual English/Spanish label from the earlier
+  JSON-approach report) where the blob fallback's distance-based matching isn't enough on its own.
 
 ## Takeaway
 
-Compared to the direct JSON-extraction approach, this is a more promising direction with a
-better-understood, narrower gap:
-
-- MiniCPM-V 4.6's OCR read accuracy is decent when it cooperates with the line-break instruction —
-  the blocking issue is mostly a data-shape mismatch between "one line per detected OCR box"
-  (what the parser was written against) and "one line per printed visual row" (what a VLM naturally
-  produces), not garbled reads.
-- ~1/3 of images ignore the "one line per line" instruction outright and return an unstructured
-  blob; this looks like a prompting problem for this specific quantization rather than a reading
-  problem, and would need a different mitigation (stronger prompt, few-shot line-break example, or
-  a parser that also tolerates run-on transcriptions).
-- If the `calories`-line-merge parser gap above were fixed for real (a small, low-risk change to
-  `parsing::parse_facts`, would also benefit the PaddleOCR path if it ever emits merged boxes), this
-  benchmark should be re-run to confirm — 6/33 is a rough upper bound from an unverified Python port,
-  not a Rust-verified number.
+- MiniCPM-V 4.6's raw OCR read accuracy is decent when line structure survives — the original
+  blocker was a data-shape mismatch between "one line per detected OCR box" (what the parser was
+  built for) and "one line per printed visual row, sometimes merged further" (what a VLM naturally
+  produces), not garbled reads. Making the parser resilient to that mismatch, rather than trying to
+  make the VLM's output match the parser's assumptions, closed most of the gap.
+- ~1/3 of images still ignore the "one line per line" instruction outright; the resilient parser
+  recovers a good chunk of these but not all — a prompting fix (stronger instruction, few-shot
+  line-break example) would likely help the hardest remaining cases more than further parser tuning.
+- This is now the best-performing MiniCPM-V 4.6 configuration tried in this investigation, and the
+  only one to beat the PaddleOCR baseline.
 
 ## How to re-run
 

--- a/nutrition-fact-labeller/eval-results/2026-07-11-smolvlm-256m-500m.md
+++ b/nutrition-fact-labeller/eval-results/2026-07-11-smolvlm-256m-500m.md
@@ -1,0 +1,102 @@
+# VLM Label Parser Eval — SmolVLM-256M and SmolVLM-500M
+
+**Date/time:** 2026-07-11 ~17:47–18:08 UTC
+**Commit:** `cd37241`
+**Models:** [ggml-org/SmolVLM-256M-Instruct-GGUF](https://huggingface.co/ggml-org/SmolVLM-256M-Instruct-GGUF), [ggml-org/SmolVLM-500M-Instruct-GGUF](https://huggingface.co/ggml-org/SmolVLM-500M-Instruct-GGUF) — `*-Q8_0.gguf` + `mmproj-*-f16.gguf`
+**Backend:** local llama.cpp (`LlavaBackend`), 4 CPU threads, no GPU
+**Harnesses:** `vlm_benchmark` (full JSON extraction) and `vlm_ocr_benchmark` (OCR-only + resilient `parsing::parse_facts_from_lines`)
+**Cases:** 33 (all of `test_cases.csv` / `images/`)
+**Runtime:** dramatically faster than MiniCPM-V 4.6 — image decode ~4–20ms/batch vs. MiniCPM's ~20–25ms/batch, and both models are ~7–19x smaller (175MB/437MB Q8_0 vs. MiniCPM's 530MB Q4_K_M on a ~8B base) — full 33-image runs completed in a few minutes each rather than ~25 minutes.
+
+## Result
+
+| Model | Approach | Pass | Fail | Score |
+|---|---|---|---|---|
+| PaddleOCR (baseline) | OCR + regex | 9 | 24 | 9/33 |
+| SmolVLM-256M-Instruct-Q8_0 | Full JSON extraction | 0 | 33 | 0/33 |
+| SmolVLM-500M-Instruct-Q8_0 | Full JSON extraction | 0 | 33 | 0/33 |
+| SmolVLM-256M-Instruct-Q8_0 | OCR-only + resilient parser | 0 | 33 | 0/33 |
+| SmolVLM-500M-Instruct-Q8_0 | OCR-only + resilient parser | 0 | 33 | 0/33 |
+
+0/33 across the board, for both model sizes and both approaches. Unlike MiniCPM-V 4.6, this isn't a
+narrow formatting/parser gap — see Diagnosis.
+
+## Diagnosis
+
+**Full-JSON approach: schema invention, not type mismatch.** MiniCPM-V 4.6 returned the right flat
+JSON shape with wrong value *types* (quoted numbers). SmolVLM does something more fundamental: it
+frequently invents its own nested JSON structure instead of following the requested schema at all,
+e.g. (`IMG_5437_1200.png`, SmolVLM-500M):
+
+```json
+{
+    "servings_per_container": {
+        "num_servings": "8",
+        "serving_size_grams": "110",
+        ...
+```
+
+— a made-up nested object where the prompt asked for a flat `"servings_per_container": <number|null>`.
+This is a JSON-schema-following failure, not a value-formatting one; grammar-constrained decoding
+would help here too (it can force the *shape* as well as leaf types) but there's a deeper capability
+gap underneath it than with MiniCPM.
+
+**OCR-only approach: doesn't do OCR, or degenerates into repetition.** Prompted with
+`OCR_TRANSCRIBE_PROMPT` ("transcribe every line of text verbatim"), neither size reliably transcribes.
+Two distinct failure modes, in different proportions per size:
+
+- **Captioning instead of transcription** (more common at 256M): the model summarizes/describes the
+  label in prose instead of reading it verbatim, e.g. `IMG_5437_1200.png` (SmolVLM-256M):
+  > "This label clearly states the nutritional information of a product, including calories,
+  > carbohydrates, protein, and total fat. The label also provides a disclaimer stating that the
+  > product is for serving only and does not contain any artificial ingredients."
+
+  This is a captioning-tuned instruct model answering "what is this" rather than "transcribe this."
+
+- **Degenerate repetition loop** (more common at 500M, 18/33 cases by a crude repeated-phrase
+  detector vs. 7/33 for 256M): the model latches onto one correct fragment and repeats it verbatim
+  until hitting the 512-token generation cap, e.g. `IMG_5437_1200.png` (SmolVLM-500M):
+  > "110 Calories. 3% Daily Value. 110 Calories per serving. 1 cup (110g) is 110 calories. 110
+  > calories per serving. 110 calories per serving. 110 calories per serving. ..." (continues for
+  > the full 512-token budget)
+
+  A classic small-model-plus-greedy-decoding failure mode. Both models occasionally get the single
+  first value right (`calories: Some(110)` matched the expected value in both examples above) but
+  produce essentially nothing else usable — nothing our resilient blob-scanning fallback
+  (`fill_gaps_from_blob`) can recover from, since there's no real content to find.
+
+## Takeaway
+
+SmolVLM-256M/500M are not viable for this task at either extraction strategy, at any quantization
+we'd realistically use. This isn't a formatting or parser problem like MiniCPM's was — it's a
+capability gap: these models don't reliably follow "transcribe verbatim" or "return this exact JSON
+shape" instructions at all, as opposed to MiniCPM-V 4.6 which followed the instructions but got
+formatting details wrong. Grammar-constrained decoding could force valid JSON *shape* out of
+SmolVLM, but wouldn't fix the underlying repetition-loop / captioning-instead-of-reading behavior,
+so it's unlikely to meaningfully move these numbers.
+
+For context on where SmolVLM sits size-wise: MiniCPM-V 4.6 (~8B) reads labels well but has
+formatting issues; SmolVLM (256M/500M) is 16-30x smaller and can't reliably read labels at all. The
+next candidates worth trying sit in between and are purpose-built for document/OCR tasks rather than
+general chat — see the research notes shared in conversation (PaddleOCR-VL-0.9B, LightOnOCR-2-1B,
+GLM-OCR-0.9B, LFM2-VL-450M) — these may hit a better size/capability tradeoff than either SmolVLM or
+MiniCPM.
+
+## How to re-run
+
+```bash
+# From nutrition-fact-labeller/, with SmolVLM weights downloaded per
+# https://huggingface.co/ggml-org/SmolVLM-256M-Instruct-GGUF and
+# https://huggingface.co/ggml-org/SmolVLM-500M-Instruct-GGUF :
+cargo run --release --bin vlm_benchmark -- \
+  --model /path/to/SmolVLM-256M-Instruct-Q8_0.gguf --mmproj /path/to/mmproj-SmolVLM-256M-Instruct-f16.gguf \
+  --model-name "SmolVLM-256M-Instruct-Q8_0" \
+  --model /path/to/SmolVLM-500M-Instruct-Q8_0.gguf --mmproj /path/to/mmproj-SmolVLM-500M-Instruct-f16.gguf \
+  --model-name "SmolVLM-500M-Instruct-Q8_0" \
+  --threads 4
+
+cargo run --release --bin vlm_ocr_benchmark -- \
+  --model /path/to/SmolVLM-256M-Instruct-Q8_0.gguf --mmproj /path/to/mmproj-SmolVLM-256M-Instruct-f16.gguf \
+  --model-name "SmolVLM-256M-Instruct-Q8_0-ocr" --threads 4
+# (repeat for 500M)
+```

--- a/nutrition-fact-labeller/eval-results/README.md
+++ b/nutrition-fact-labeller/eval-results/README.md
@@ -10,11 +10,21 @@ Harnesses:
 - `cargo run --release --bin vlm_benchmark` — VLM does the full image → structured JSON extraction.
 - `cargo run --release --bin vlm_ocr_benchmark` — VLM is used purely as OCR; output goes through
   the shared `parsing::parse_facts_from_lines` regex/spellcheck parser (same one PaddleOCR uses).
+  Both binaries accept `--limit N` to cap the number of images processed (useful for a quick smoke
+  test — see below).
 - PaddleOCR baseline — the default non-LLM backend (`run_ocr_rgb` + `parse_facts_from_regions` in
   `main.rs`), scored via the `check_test_cases` test. **Not independently re-verified in this
   environment** — that test needs local PaddleOCR ONNX model weight files
   (`paddleocr-models/*.onnx`) that aren't present in this sandbox. The 9/33 baseline figure is
   taken from the pre-existing `BASELINE_PASS`/`BASELINE_TOTAL` constants in `vlm_benchmark.rs`.
+
+**Model manifest:** [`models.toml`](../models.toml) is the single source of truth for every model
+this project is tracking — HF repo, filenames, confirmed llama.cpp projector-type support, and
+notes/status per model. `scripts/fetch-model.sh <key>` downloads a model's files from the
+manifest; `scripts/run-eval.sh <key> [--smoke [N]]` fetches (if needed) and runs both harnesses.
+`--smoke` runs just 2 images (or N) to verify a model loads and produces real output without
+committing to a full 33-image run — see "Smoke-tested, not yet fully evaluated" below for models
+that are ready for a full run whenever compute allows.
 
 ## Results
 
@@ -31,6 +41,33 @@ Harnesses:
 
 Commit = the code state the run was actually executed against (usually the commit that lands
 right after the run, since reports are written and committed once results are in hand).
+
+## Smoke-tested, not yet fully evaluated
+
+These 9 models (see `models.toml` for full details, HF repos, and per-model notes) were verified
+to load and run via `scripts/run-eval.sh <key> --smoke` (2 images, OCR-only harness) on 2026-07-11
+at commit `6b14913`, but **no full 33-image eval has been run for any of them** — that's next, on
+faster hardware. Ranked by smoke-test signal:
+
+| Model | Size | Category | Smoke result | Signal |
+|---|---|---|---|---|
+| LightOnOCR-1B-1025 | 1B | dedicated OCR | 1/2 pass, clean bilingual markdown-table transcription | 🟢 strong |
+| GLM-OCR | 0.9B | dedicated OCR | 1/2 pass, other miss off by exactly 1 field (label-layout edge case) | 🟢 strong |
+| LFM2.5-VL-1.6B | 1.6B | general | 1/2 pass, solid bilingual transcription | 🟢 strong |
+| InternVL3-1B-Instruct | 1B | general | 1/2 pass, other degrades into repetition partway through | 🟡 mixed |
+| GLM-Edge-V-2B | 2B | general | 1/2 pass, other miss summarizes in prose instead of transcribing | 🟡 mixed |
+| LFM2-VL-450M | 450M | general | 0/2, but real/mostly-accurate transcription | 🟡 mixed |
+| PaddleOCR-VL-0.9B | 0.9B | dedicated OCR | 0/2, degenerate "Only text." repetition — likely a chat-template gap, not capability (see notes) | 🟡 inconclusive |
+| Qwen2-VL-2B-Instruct | 2B | general | 0/2, emits grounding/bbox tokens instead of text — likely a prompt-wording issue (see notes) | 🟡 inconclusive |
+| moondream2 | 1.9B | general | 0/2, explicitly refuses to transcribe in prose | 🔴 weak |
+
+None of these crashed or hit an `unknown projector type` error — all 9 vision projector types
+(`paddleocr`, `lightonocr`, `glm4v`, `lfm2` ×2, `mlp`, `internvl`, `qwen2vl_merger`, `adapter`) are
+confirmed supported by the vendored llama.cpp. Suggested order for the full run: LightOnOCR-1B,
+GLM-OCR, and LFM2.5-VL-1.6B first (clearest positive signal), then the "mixed" tier, then
+PaddleOCR-VL and Qwen2-VL-2B only after trying the prompt/template fixes noted in `models.toml`
+(their smoke failures look environmental rather than capability-based), with moondream2 lowest
+priority given its outright refusal behavior.
 
 ## Known issues (synthesized across runs — update as new patterns show up)
 
@@ -83,13 +120,19 @@ right after the run, since reports are written and committed once results are in
 
 ## Adding a new model to this table
 
-1. Download the model + mmproj GGUF (must have `llama.cpp` mtmd support for the model's vision
-   projector type — check `llama-cpp-sys-2`'s vendored `clip-impl.h` `PROJECTOR_TYPE_NAMES` if
-   unsure, or just try it and read the `unknown projector type: ...` error if it fails).
-2. Run `vlm_benchmark` and/or `vlm_ocr_benchmark` (see harness commands above) from
-   `nutrition-fact-labeller/`.
-3. Note `git rev-parse HEAD` (short form is fine) and the current UTC time.
-4. Write a dated report (`eval-results/YYYY-MM-DD-<model>-<approach>.md`) following the existing
+1. Add a `[models.<key>]` entry to [`models.toml`](../models.toml) with the HF repo and exact
+   model/mmproj filenames (check the repo's file listing). Note the vision projector type if you
+   can find it — check `llama-cpp-sys-2`'s vendored `clip-impl.h` `PROJECTOR_TYPE_NAMES` map for
+   whether it's supported at all; if unsure, just try it and read the `unknown projector type:
+   ...` error if it fails, or the `load_hparams: projector: <name>` line it logs on success.
+2. `./scripts/run-eval.sh <key> --smoke` first — cheap (2 images), confirms the model loads and
+   produces real output before committing to a full run. Update the model's `status` and `notes`
+   in `models.toml` with what you saw (see the "Smoke-tested" entries above for the expected
+   level of detail), and add a row to the smoke-test table above if it's a new model.
+3. `./scripts/run-eval.sh <key>` for the full 33-image run once you're ready to commit the compute.
+4. Note `git rev-parse HEAD` (short form is fine) and the current UTC time.
+5. Write a dated report (`eval-results/YYYY-MM-DD-<model>-<approach>.md`) following the existing
    reports' structure: Result table, Diagnosis of failure modes, Takeaway, How to re-run.
-5. Append a row to the Results table above, and fold any newly-discovered failure pattern into
-   Known Issues (or update an existing entry if it's the same root cause recurring).
+6. Append a row to the Results table above (and remove it from the "Smoke-tested, not yet fully
+   evaluated" table), and fold any newly-discovered failure pattern into Known Issues (or update
+   an existing entry if it's the same root cause recurring).

--- a/nutrition-fact-labeller/eval-results/README.md
+++ b/nutrition-fact-labeller/eval-results/README.md
@@ -1,0 +1,81 @@
+# VLM Label Parser — Living Eval Summary
+
+This is the running index of every label-parsing eval run against `nutrition-fact-labeller`'s
+33-case `test_cases.csv` / `images/` suite. Each row links to a dated report with the full
+methodology, raw findings, and takeaways. **Update this file whenever a new eval is run** —
+append a row, link the detailed report, and fold any new failure pattern into the Known Issues
+section below so it doesn't get rediscovered from scratch next time.
+
+Harnesses:
+- `cargo run --release --bin vlm_benchmark` — VLM does the full image → structured JSON extraction.
+- `cargo run --release --bin vlm_ocr_benchmark` — VLM is used purely as OCR; output goes through
+  the shared `parsing::parse_facts_from_lines` regex/spellcheck parser (same one PaddleOCR uses).
+- PaddleOCR baseline — the default non-LLM backend (`run_ocr_rgb` + `parse_facts_from_regions` in
+  `main.rs`), scored via the `check_test_cases` test. **Not independently re-verified in this
+  environment** — that test needs local PaddleOCR ONNX model weight files
+  (`paddleocr-models/*.onnx`) that aren't present in this sandbox. The 9/33 baseline figure is
+  taken from the pre-existing `BASELINE_PASS`/`BASELINE_TOTAL` constants in `vlm_benchmark.rs`.
+
+## Results
+
+| Date/time (UTC) | Commit | Model | Approach | Score | vs. baseline (9/33) | Report |
+|---|---|---|---|---|---|---|
+| 2026-07-11 01:42 | `7745229` | MiniCPM-V-4.6-Q4_K_M | Full JSON extraction | 0/33 | ▼ −9 | [2026-07-11-minicpm-v-4.6-q4_k_m.md](2026-07-11-minicpm-v-4.6-q4_k_m.md) |
+| 2026-07-11 03:15 | `a1db43e` | MiniCPM-V-4.6-Q4_K_M | OCR-only, original line-based parser | 0/33 | ▼ −9 | [2026-07-11-minicpm-v-4.6-ocr-only.md](2026-07-11-minicpm-v-4.6-ocr-only.md) |
+| 2026-07-11 17:11 | `0003ea0` | MiniCPM-V-4.6-Q4_K_M | OCR-only, resilient parser (blob fallback) | **11/33** | **▲ +2** | [2026-07-11-minicpm-v-4.6-ocr-only.md](2026-07-11-minicpm-v-4.6-ocr-only.md) |
+| _pending_ | _pending_ | SmolVLM-256M-Instruct-Q8_0 | Full JSON extraction | _pending_ | | |
+| _pending_ | _pending_ | SmolVLM-500M-Instruct-Q8_0 | Full JSON extraction | _pending_ | | |
+| _pending_ | _pending_ | SmolVLM-256M-Instruct-Q8_0 | OCR-only, resilient parser | _pending_ | | |
+| _pending_ | _pending_ | SmolVLM-500M-Instruct-Q8_0 | OCR-only, resilient parser | _pending_ | | |
+| — | — | PaddleOCR (baseline) | OCR + regex, unmodified | 9/33 | = | not independently re-verified here; see caveat above |
+
+Commit = the code state the run was actually executed against (usually the commit that lands
+right after the run, since reports are written and committed once results are in hand).
+
+## Known issues (synthesized across runs — update as new patterns show up)
+
+1. **JSON type-strictness (full-JSON-extraction approach).** MiniCPM-V 4.6 mostly reads label
+   values correctly but returns them as JSON *strings*, often with units baked in (`"30g"`,
+   `"<1g"`) instead of bare numbers, despite the prompt explicitly asking for `<number|null>`.
+   `serde_json::from_str::<ParsedNutritionFacts>` is strict about field types, so this fails
+   deserialization outright rather than producing a wrong-but-parseable result. **Not yet fixed**
+   — candidate fixes (discussed, not built): a lenient coercion layer over `serde_json::Value`
+   before deserializing, or grammar-constrained decoding (`llama-cpp-2` already exposes
+   `LlamaSampler::grammar()` / an `llguidance` JSON-schema sampler) to force numeric-typed output
+   at generation time.
+
+2. **Line-orientation mismatch (OCR-only approach, now largely mitigated).** `parse_facts`
+   (`parsing.rs`) was written assuming roughly one label per line, matching PaddleOCR's
+   per-detected-text-box output. VLM transcriptions don't reliably match that shape: they often
+   merge a label and its value onto one line (`"Calories 110"` instead of separate lines), and in
+   ~1/3 of images ignored the "one line per line" transcription instruction entirely, collapsing
+   the whole label into a single run-on paragraph. Fixed by `fill_gaps_from_blob` — an additive
+   fallback that scans the full transcription text and picks, per field, the nearest number by
+   character distance regardless of line breaks — which took MiniCPM's OCR-only score from 0/33 to
+   11/33 (see the 2026-07-11 17:11 run above). Remaining gaps: ~7/22 failures are still off by one
+   field (mostly on labels where the correct number falls outside the fallback's search window or
+   a nearer wrong number wins), and 2/22 badly-collapsed/bilingual cases aren't recovered by
+   distance-based matching alone.
+
+3. **PaddleOCR baseline isn't independently verifiable in this environment.** `check_test_cases`
+   needs local ONNX weight files (`paddleocr-models/*.onnx`) that aren't present in this sandbox,
+   so its own 9/33 score comes from the pre-existing constants in the codebase rather than a fresh
+   run here. Flag this if the baseline itself is ever in question.
+
+4. **Fine-tuning is likely premature.** Discussed but not attempted: this environment has no GPU,
+   and the 33-case test set is far too small to fine-tune on directly (and using it as training
+   data would remove the only eval set available). Worth revisiting only if structured-output /
+   coercion fixes for issue #1 leave a value-*accuracy* gap rather than a formatting gap.
+
+## Adding a new model to this table
+
+1. Download the model + mmproj GGUF (must have `llama.cpp` mtmd support for the model's vision
+   projector type — check `llama-cpp-sys-2`'s vendored `clip-impl.h` `PROJECTOR_TYPE_NAMES` if
+   unsure, or just try it and read the `unknown projector type: ...` error if it fails).
+2. Run `vlm_benchmark` and/or `vlm_ocr_benchmark` (see harness commands above) from
+   `nutrition-fact-labeller/`.
+3. Note `git rev-parse HEAD` (short form is fine) and the current UTC time.
+4. Write a dated report (`eval-results/YYYY-MM-DD-<model>-<approach>.md`) following the existing
+   reports' structure: Result table, Diagnosis of failure modes, Takeaway, How to re-run.
+5. Append a row to the Results table above, and fold any newly-discovered failure pattern into
+   Known Issues (or update an existing entry if it's the same root cause recurring).

--- a/nutrition-fact-labeller/eval-results/README.md
+++ b/nutrition-fact-labeller/eval-results/README.md
@@ -23,10 +23,10 @@ Harnesses:
 | 2026-07-11 01:42 | `7745229` | MiniCPM-V-4.6-Q4_K_M | Full JSON extraction | 0/33 | ▼ −9 | [2026-07-11-minicpm-v-4.6-q4_k_m.md](2026-07-11-minicpm-v-4.6-q4_k_m.md) |
 | 2026-07-11 03:15 | `a1db43e` | MiniCPM-V-4.6-Q4_K_M | OCR-only, original line-based parser | 0/33 | ▼ −9 | [2026-07-11-minicpm-v-4.6-ocr-only.md](2026-07-11-minicpm-v-4.6-ocr-only.md) |
 | 2026-07-11 17:11 | `0003ea0` | MiniCPM-V-4.6-Q4_K_M | OCR-only, resilient parser (blob fallback) | **11/33** | **▲ +2** | [2026-07-11-minicpm-v-4.6-ocr-only.md](2026-07-11-minicpm-v-4.6-ocr-only.md) |
-| _pending_ | _pending_ | SmolVLM-256M-Instruct-Q8_0 | Full JSON extraction | _pending_ | | |
-| _pending_ | _pending_ | SmolVLM-500M-Instruct-Q8_0 | Full JSON extraction | _pending_ | | |
-| _pending_ | _pending_ | SmolVLM-256M-Instruct-Q8_0 | OCR-only, resilient parser | _pending_ | | |
-| _pending_ | _pending_ | SmolVLM-500M-Instruct-Q8_0 | OCR-only, resilient parser | _pending_ | | |
+| 2026-07-11 17:53 | `cd37241` | SmolVLM-256M-Instruct-Q8_0 | Full JSON extraction | 0/33 | ▼ −9 | [2026-07-11-smolvlm-256m-500m.md](2026-07-11-smolvlm-256m-500m.md) |
+| 2026-07-11 17:53 | `cd37241` | SmolVLM-500M-Instruct-Q8_0 | Full JSON extraction | 0/33 | ▼ −9 | [2026-07-11-smolvlm-256m-500m.md](2026-07-11-smolvlm-256m-500m.md) |
+| 2026-07-11 18:08 | `cd37241` | SmolVLM-256M-Instruct-Q8_0 | OCR-only, resilient parser | 0/33 | ▼ −9 | [2026-07-11-smolvlm-256m-500m.md](2026-07-11-smolvlm-256m-500m.md) |
+| 2026-07-11 18:08 | `cd37241` | SmolVLM-500M-Instruct-Q8_0 | OCR-only, resilient parser | 0/33 | ▼ −9 | [2026-07-11-smolvlm-256m-500m.md](2026-07-11-smolvlm-256m-500m.md) |
 | — | — | PaddleOCR (baseline) | OCR + regex, unmodified | 9/33 | = | not independently re-verified here; see caveat above |
 
 Commit = the code state the run was actually executed against (usually the commit that lands
@@ -66,6 +66,20 @@ right after the run, since reports are written and committed once results are in
    and the 33-case test set is far too small to fine-tune on directly (and using it as training
    data would remove the only eval set available). Worth revisiting only if structured-output /
    coercion fixes for issue #1 leave a value-*accuracy* gap rather than a formatting gap.
+
+5. **Model-size capability cliff, not just a formatting problem.** SmolVLM-256M/500M scored 0/33 on
+   *both* approaches, but not for MiniCPM's reasons. On full-JSON extraction they invent their own
+   nested JSON structure instead of following the requested flat schema (a shape failure, not a
+   type failure). On OCR-only they either caption/describe the label in prose instead of
+   transcribing it verbatim, or fall into a degenerate repetition loop (e.g. "110 calories per
+   serving." repeated ~60 times) until hitting the token budget. Neither failure mode is something
+   `fill_gaps_from_blob` or a JSON coercion layer can fix — there's no real content to recover.
+   Conclusion: below some model-size threshold between SmolVLM (256M/500M) and MiniCPM-V 4.6
+   (~8B), instruction-following for "transcribe verbatim" / "match this exact schema" breaks down
+   entirely, not just gets formatted wrong. Worth testing something in between — dedicated small
+   OCR/document models (PaddleOCR-VL-0.9B, LightOnOCR-2-1B, GLM-OCR-0.9B) or LFM2-VL-450M are
+   likely better bets than another general-purpose chat VLM at a similar size, since they're
+   trained specifically for dense-text transcription rather than captioning/chat.
 
 ## Adding a new model to this table
 

--- a/nutrition-fact-labeller/models.toml
+++ b/nutrition-fact-labeller/models.toml
@@ -1,0 +1,197 @@
+# Manifest of VLM candidates for the label-parser eval harness (vlm_benchmark /
+# vlm_ocr_benchmark). This is the single source of truth for "which models are we
+# tracking" — see scripts/fetch-model.sh and scripts/run-eval.sh, which both key off
+# the [models.<key>] tables below, and eval-results/README.md for results once run.
+#
+# Deployment target for all of these: CPU-only, limited memory, potentially in-browser
+# eventually — hence the focus on sub-2B models. See eval-results/README.md's Known
+# Issues section for why general small chat VLMs (SmolVLM) struggled and dedicated
+# small OCR/document models are the more promising next tier.
+#
+# To add a model: add a [models.<key>] entry below (find hf_repo + filenames from the
+# model's HF repo file listing), then:
+#   ./scripts/fetch-model.sh <key>
+#   ./scripts/run-eval.sh <key> --smoke     # verify it loads/runs (cheap, 2 images)
+#   ./scripts/run-eval.sh <key>              # full 33-image eval, both harnesses
+
+[models.minicpm-v-4_6]
+display_name = "MiniCPM-V-4.6-Q4_K_M"
+hf_repo = "openbmb/MiniCPM-V-4.6-gguf"
+model_file = "MiniCPM-V-4_6-Q4_K_M.gguf"
+mmproj_file = "mmproj-model-f16.gguf"
+projector_type = "minicpmv4_6"
+category = "already-evaluated"
+status = "evaluated"
+notes = """
+Requires llama-cpp-2 >= 0.1.151 for minicpmv4_6 projector support (see commit
+26696d9). 0/33 full-JSON (returns numbers as quoted strings with units, e.g. "30g");
+11/33 OCR-only + resilient parser, beating the 9/33 PaddleOCR baseline. See
+eval-results/2026-07-11-minicpm-v-4.6-q4_k_m.md and
+eval-results/2026-07-11-minicpm-v-4.6-ocr-only.md.
+"""
+
+[models.smolvlm-256m]
+display_name = "SmolVLM-256M-Instruct-Q8_0"
+hf_repo = "ggml-org/SmolVLM-256M-Instruct-GGUF"
+model_file = "SmolVLM-256M-Instruct-Q8_0.gguf"
+mmproj_file = "mmproj-SmolVLM-256M-Instruct-f16.gguf"
+projector_type = "idefics3"
+category = "already-evaluated"
+status = "evaluated"
+notes = """
+0/33 on both approaches. Full-JSON: invents its own nested JSON schema instead of the
+requested flat one. OCR-only: captions the label in prose instead of transcribing it
+verbatim. See eval-results/2026-07-11-smolvlm-256m-500m.md.
+"""
+
+[models.smolvlm-500m]
+display_name = "SmolVLM-500M-Instruct-Q8_0"
+hf_repo = "ggml-org/SmolVLM-500M-Instruct-GGUF"
+model_file = "SmolVLM-500M-Instruct-Q8_0.gguf"
+mmproj_file = "mmproj-SmolVLM-500M-Instruct-f16.gguf"
+projector_type = "idefics3"
+category = "already-evaluated"
+status = "evaluated"
+notes = """
+0/33 on both approaches. Full-JSON: same schema-invention failure as the 256M variant.
+OCR-only: degenerate repetition loop (repeats one correct fragment ~60x until hitting
+the token budget) more often than the 256M variant. See
+eval-results/2026-07-11-smolvlm-256m-500m.md.
+"""
+
+# --- Not yet evaluated: dedicated small OCR/document models ---
+# These are purpose-trained for dense verbatim text/structure extraction rather than
+# general chat/captioning, so they're the most promising next tier after SmolVLM's
+# capability-cliff failure (see eval-results/README.md Known Issues #5).
+
+[models.paddleocr-vl]
+display_name = "PaddleOCR-VL-0.9B"
+hf_repo = "PaddlePaddle/PaddleOCR-VL-1.6-GGUF"
+model_file = "PaddleOCR-VL-1.6-GGUF.gguf"
+mmproj_file = "PaddleOCR-VL-1.6-GGUF-mmproj.gguf"
+projector_type = "paddleocr"
+category = "dedicated-ocr"
+status = "not-yet-tested"
+notes = """
+0.9B (NaViT vision encoder + ERNIE-4.5-0.3B). Direct descendant of the PaddleOCR
+engine we already use as the non-LLM baseline — a natural "upgrade path" test.
+Upstream docs (huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF) say llama-server
+needs --jinja plus an explicit --chat-template-file or the model crashes; our
+LlavaBackend only tries the model's *embedded* chat template
+(model.chat_template(None)) with a raw-prompt fallback, so if the embedded template is
+missing/incompatible we fall back to the untemplated prompt rather than crashing —
+but that may hurt output quality. Worth revisiting the prompt-building path in
+llava.rs if this scores poorly for templating reasons rather than capability reasons.
+"""
+
+[models.lightonocr-1b]
+display_name = "LightOnOCR-1B-1025-Q8_0"
+hf_repo = "ggml-org/LightOnOCR-1B-1025-GGUF"
+model_file = "LightOnOCR-1B-1025-Q8_0.gguf"
+mmproj_file = "mmproj-LightOnOCR-1B-1025-Q8_0.gguf"
+projector_type = "lightonocr"
+category = "dedicated-ocr"
+status = "not-yet-tested"
+notes = """
+1B, end-to-end multilingual document OCR model. Upstream docs warn not to quantize
+the mmproj more aggressively than Q8_0/F16 — we already default to that.
+"""
+
+[models.glm-ocr]
+display_name = "GLM-OCR-Q8_0"
+hf_repo = "ggml-org/GLM-OCR-GGUF"
+model_file = "GLM-OCR-Q8_0.gguf"
+mmproj_file = "mmproj-GLM-OCR-Q8_0.gguf"
+projector_type = "glm4v"
+category = "dedicated-ocr"
+status = "not-yet-tested"
+notes = """
+0.9B, glm4 architecture. Released March 2026, tops OmniDocBench (94.62) among
+sub-2B document models per public benchmarks — the strongest specialized-OCR
+candidate by reputation, not yet verified on our specific label-extraction task.
+"""
+
+# --- Not yet evaluated: small general-purpose VLMs ---
+# Extends the SmolVLM/MiniCPM comparison with models between them in size, or with an
+# explicit edge/on-device design target.
+
+[models.lfm2-vl-450m]
+display_name = "LFM2-VL-450M-Q8_0"
+hf_repo = "LiquidAI/LFM2-VL-450M-GGUF"
+model_file = "LFM2-VL-450M-Q8_0.gguf"
+mmproj_file = "mmproj-LFM2-VL-450M-Q8_0.gguf"
+projector_type = "lfm2"
+category = "general-small-vlm"
+status = "not-yet-tested"
+notes = """
+450M, Liquid AI's edge-first VLM line, named directly in ggml-org's own "using OCR
+models with llama.cpp" reference post as one of their small-model examples.
+"""
+
+[models.lfm25-vl-1_6b]
+display_name = "LFM2.5-VL-1.6B-Q8_0"
+hf_repo = "LiquidAI/LFM2.5-VL-1.6B-GGUF"
+model_file = "LFM2.5-VL-1.6B-Q8_0.gguf"
+mmproj_file = "mmproj-LFM2.5-VL-1.6b-Q8_0.gguf"
+projector_type = "lfm2"
+category = "general-small-vlm"
+status = "not-yet-tested"
+notes = """
+1.6B (1.2B LLM + 400M vision encoder). Also has an official ONNX/WebGPU build for
+in-browser deployment (separate from this GGUF/llama.cpp path) — see
+"LFM-2.5VL-1.6B: The Vision Model That Runs in Your Browser" (runyard.dev), relevant
+if the in-browser deployment target becomes concrete rather than aspirational.
+"""
+
+[models.moondream2]
+display_name = "moondream2"
+hf_repo = "ggml-org/moondream2-20250414-GGUF"
+model_file = "moondream2-text-model-f16_ct-vicuna.gguf"
+mmproj_file = "moondream2-mmproj-f16-20250414.gguf"
+projector_type = "unconfirmed"
+category = "general-small-vlm"
+status = "not-yet-tested"
+notes = """
+~1.9B, F16 only (no smaller quant offered upstream for this GGUF release — ~3.6GB
+combined, largest of this batch). Already referenced in our own llava.rs doc comment
+("LLaVA-style GGUF models (moondream2, llava-phi3, etc.)") as an anticipated backend,
+so someone on this project had it in mind before this eval effort. Projector type
+wasn't found by name in our vendored llama.cpp's PROJECTOR_TYPE_NAMES map (no
+"moondream"-named entry) — it likely maps onto a generic type from its GGUF metadata;
+confirm via the projector name llama.cpp logs on load.
+"""
+
+[models.internvl3-1b]
+display_name = "InternVL3-1B-Instruct-Q8_0"
+hf_repo = "ggml-org/InternVL3-1B-Instruct-GGUF"
+model_file = "InternVL3-1B-Instruct-Q8_0.gguf"
+mmproj_file = "mmproj-InternVL3-1B-Instruct-Q8_0.gguf"
+projector_type = "internvl"
+category = "general-small-vlm"
+status = "not-yet-tested"
+notes = "1B. InternVL's training mix has a strong document/OCR emphasis."
+
+[models.qwen2vl-2b]
+display_name = "Qwen2-VL-2B-Instruct-Q4_K_M"
+hf_repo = "bartowski/Qwen2-VL-2B-Instruct-GGUF"
+model_file = "Qwen2-VL-2B-Instruct-Q4_K_M.gguf"
+mmproj_file = "mmproj-Qwen2-VL-2B-Instruct-f16.gguf"
+projector_type = "qwen2vl_merger"
+category = "general-small-vlm"
+status = "not-yet-tested"
+notes = """
+2B, at the upper edge of "very small" for this project but included as one data
+point given Qwen's known strength on chart/document understanding. Qwen3-VL-2B may
+be worth substituting once a llama.cpp-compatible GGUF quant is readily available
+(not confirmed as of this manifest's creation).
+"""
+
+[models.glm-edge-v-2b]
+display_name = "GLM-Edge-V-2B-Q4_K_M"
+hf_repo = "zai-org/glm-edge-v-2b-gguf"
+model_file = "ggml-model-Q4_K_M.gguf"
+mmproj_file = "mmproj-model-f16.gguf"
+projector_type = "adapter"
+category = "general-small-vlm"
+status = "not-yet-tested"
+notes = "2B, Zhipu's edge/on-device-targeted VLM line."

--- a/nutrition-fact-labeller/models.toml
+++ b/nutrition-fact-labeller/models.toml
@@ -71,17 +71,22 @@ model_file = "PaddleOCR-VL-1.6-GGUF.gguf"
 mmproj_file = "PaddleOCR-VL-1.6-GGUF-mmproj.gguf"
 projector_type = "paddleocr"
 category = "dedicated-ocr"
-status = "not-yet-tested"
+status = "smoke-tested-ok"
 notes = """
 0.9B (NaViT vision encoder + ERNIE-4.5-0.3B). Direct descendant of the PaddleOCR
 engine we already use as the non-LLM baseline — a natural "upgrade path" test.
-Upstream docs (huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF) say llama-server
-needs --jinja plus an explicit --chat-template-file or the model crashes; our
-LlavaBackend only tries the model's *embedded* chat template
-(model.chat_template(None)) with a raw-prompt fallback, so if the embedded template is
-missing/incompatible we fall back to the untemplated prompt rather than crashing —
-but that may hurt output quality. Worth revisiting the prompt-building path in
-llava.rs if this scores poorly for templating reasons rather than capability reasons.
+SMOKE TEST (2026-07-11, --smoke, 2 images): loads and runs without error (projector
+"paddleocr" accepted; note this model produces a very large number of vision tokens
+for our label photos — ~1230 image-decode batches vs. ~60-700 for most other
+candidates here, so expect it to be the slowest of this batch per image). Output
+quality was poor in the smoke test: degenerated into repeating "Only text." rather
+than transcribing, on both smoke images. Matches the concern noted above — upstream
+docs (huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5-GGUF) say llama-server needs
+--jinja plus an explicit --chat-template-file or the model misbehaves; our
+LlavaBackend only tries the model's *embedded* chat template (model.chat_template(None))
+with a raw-prompt fallback. Before a full run, worth checking whether this GGUF's
+embedded template is the issue (llava.rs may need a template override path for this
+model specifically) rather than writing this model off as a capability failure.
 """
 
 [models.lightonocr-1b]
@@ -91,10 +96,15 @@ model_file = "LightOnOCR-1B-1025-Q8_0.gguf"
 mmproj_file = "mmproj-LightOnOCR-1B-1025-Q8_0.gguf"
 projector_type = "lightonocr"
 category = "dedicated-ocr"
-status = "not-yet-tested"
+status = "smoke-tested-ok"
 notes = """
 1B, end-to-end multilingual document OCR model. Upstream docs warn not to quantize
 the mmproj more aggressively than Q8_0/F16 — we already default to that.
+SMOKE TEST (2026-07-11, --smoke, 2 images): loads and runs cleanly (projector
+"lightonocr" accepted). **Passed 1/2 smoke images outright** — the only new candidate
+to do so on the OCR-only harness in this smoke round. Transcribes into well-structured
+bilingual markdown tables (`| Sodium/Sodio 180mg | 8% | 11% |`) with accurate values.
+Top priority for the full 33-image run.
 """
 
 [models.glm-ocr]
@@ -104,11 +114,18 @@ model_file = "GLM-OCR-Q8_0.gguf"
 mmproj_file = "mmproj-GLM-OCR-Q8_0.gguf"
 projector_type = "glm4v"
 category = "dedicated-ocr"
-status = "not-yet-tested"
+status = "smoke-tested-ok"
 notes = """
 0.9B, glm4 architecture. Released March 2026, tops OmniDocBench (94.62) among
 sub-2B document models per public benchmarks — the strongest specialized-OCR
-candidate by reputation, not yet verified on our specific label-extraction task.
+candidate by reputation.
+SMOKE TEST (2026-07-11, --smoke, 2 images): loads and runs cleanly (projector
+"glm4v" accepted). **Passed 1/2 smoke images outright**; the other miss was off by
+exactly one field (calories) because that specific label's layout doesn't repeat the
+word "Calories" next to its two calorie-count columns ("150"/"210" appear bare) — a
+label-layout edge case, not a transcription error; every other field matched exactly
+including bilingual text and added-sugars. Alongside LightOnOCR-1B, top priority for
+the full 33-image run — reputation and smoke-test quality both point the same way.
 """
 
 # --- Not yet evaluated: small general-purpose VLMs ---
@@ -122,10 +139,15 @@ model_file = "LFM2-VL-450M-Q8_0.gguf"
 mmproj_file = "mmproj-LFM2-VL-450M-Q8_0.gguf"
 projector_type = "lfm2"
 category = "general-small-vlm"
-status = "not-yet-tested"
+status = "smoke-tested-ok"
 notes = """
 450M, Liquid AI's edge-first VLM line, named directly in ggml-org's own "using OCR
 models with llama.cpp" reference post as one of their small-model examples.
+SMOKE TEST (2026-07-11, --smoke, 2 images): loads and runs cleanly (projector "lfm2"
+accepted). 0/2 pass, but the transcription is real and mostly accurate (bilingual
+text, most values correct) — the miss was largely a missed servings_per_container and
+a couple of merged-line issues our resilient parser didn't fully untangle at n=2.
+Promising for its size class; worth the full run.
 """
 
 [models.lfm25-vl-1_6b]
@@ -135,12 +157,15 @@ model_file = "LFM2.5-VL-1.6B-Q8_0.gguf"
 mmproj_file = "mmproj-LFM2.5-VL-1.6b-Q8_0.gguf"
 projector_type = "lfm2"
 category = "general-small-vlm"
-status = "not-yet-tested"
+status = "smoke-tested-ok"
 notes = """
 1.6B (1.2B LLM + 400M vision encoder). Also has an official ONNX/WebGPU build for
 in-browser deployment (separate from this GGUF/llama.cpp path) — see
 "LFM-2.5VL-1.6B: The Vision Model That Runs in Your Browser" (runyard.dev), relevant
 if the in-browser deployment target becomes concrete rather than aspirational.
+SMOKE TEST (2026-07-11, --smoke, 2 images): loads and runs cleanly (projector "lfm2"
+accepted). **Passed 1/2 smoke images outright**; solid bilingual transcription
+quality on the other. A strong general-VLM candidate for the full run.
 """
 
 [models.moondream2]
@@ -148,17 +173,23 @@ display_name = "moondream2"
 hf_repo = "ggml-org/moondream2-20250414-GGUF"
 model_file = "moondream2-text-model-f16_ct-vicuna.gguf"
 mmproj_file = "moondream2-mmproj-f16-20250414.gguf"
-projector_type = "unconfirmed"
+projector_type = "mlp"
 category = "general-small-vlm"
-status = "not-yet-tested"
+status = "smoke-tested-ok"
 notes = """
 ~1.9B, F16 only (no smaller quant offered upstream for this GGUF release — ~3.6GB
 combined, largest of this batch). Already referenced in our own llava.rs doc comment
 ("LLaVA-style GGUF models (moondream2, llava-phi3, etc.)") as an anticipated backend,
-so someone on this project had it in mind before this eval effort. Projector type
-wasn't found by name in our vendored llama.cpp's PROJECTOR_TYPE_NAMES map (no
-"moondream"-named entry) — it likely maps onto a generic type from its GGUF metadata;
-confirm via the projector name llama.cpp logs on load.
+so someone on this project had it in mind before this eval effort.
+SMOKE TEST (2026-07-11, --smoke, 2 images): loads and runs cleanly — confirmed
+projector type is "mlp" (updated above; wasn't findable by name in advance). 0/2:
+on both smoke images it explicitly refused the transcription request in prose
+("I am sorry, but I cannot generate a text that is exactly like the image you
+provided...") rather than attempting it — a refusal/instruction-following failure
+distinct from SmolVLM's captioning tendency or the repetition-loop failures seen
+elsewhere. May respond better to a differently-worded prompt (moondream2 is tuned
+more for Q&A/captioning than literal transcription); worth a prompt variant before
+writing it off, otherwise deprioritize versus the dedicated-OCR candidates above.
 """
 
 [models.internvl3-1b]
@@ -168,8 +199,16 @@ model_file = "InternVL3-1B-Instruct-Q8_0.gguf"
 mmproj_file = "mmproj-InternVL3-1B-Instruct-Q8_0.gguf"
 projector_type = "internvl"
 category = "general-small-vlm"
-status = "not-yet-tested"
-notes = "1B. InternVL's training mix has a strong document/OCR emphasis."
+status = "smoke-tested-ok"
+notes = """
+1B. InternVL's training mix has a strong document/OCR emphasis.
+SMOKE TEST (2026-07-11, --smoke, 2 images): loads and runs cleanly (projector
+"internvl" accepted). Passed 1/2 smoke images outright; the other transcription
+starts strong (accurate bilingual text) but fragments into broken partial words
+partway through and degenerates into repeating "350mg" near the end — a milder
+version of the repetition-loop failure mode seen in SmolVLM-500M. Worth the full
+run, but expect some images to hit this degradation.
+"""
 
 [models.qwen2vl-2b]
 display_name = "Qwen2-VL-2B-Instruct-Q4_K_M"
@@ -178,12 +217,21 @@ model_file = "Qwen2-VL-2B-Instruct-Q4_K_M.gguf"
 mmproj_file = "mmproj-Qwen2-VL-2B-Instruct-f16.gguf"
 projector_type = "qwen2vl_merger"
 category = "general-small-vlm"
-status = "not-yet-tested"
+status = "smoke-tested-ok"
 notes = """
 2B, at the upper edge of "very small" for this project but included as one data
 point given Qwen's known strength on chart/document understanding. Qwen3-VL-2B may
 be worth substituting once a llama.cpp-compatible GGUF quant is readily available
 (not confirmed as of this manifest's creation).
+SMOKE TEST (2026-07-11, --smoke, 2 images): loads and runs cleanly (projector
+"qwen2vl_merger" accepted). 0/2 — on both smoke images it emitted a grounding/
+bounding-box token instead of transcribed text (e.g. `<|box_start|>(182,10),
+(812,995)<|box_end|>`), i.e. it interpreted the prompt as an object-detection/
+grounding request rather than a transcription request. This looks like a prompt
+wording issue specific to Qwen2-VL's instruction-tuned behaviors (it has dedicated
+grounding capabilities our OCR_TRANSCRIBE_PROMPT's wording may be triggering) rather
+than a capability gap — worth trying a more explicit "read the text, do not describe
+locations" prompt variant before concluding this model can't do the task.
 """
 
 [models.glm-edge-v-2b]
@@ -193,5 +241,13 @@ model_file = "ggml-model-Q4_K_M.gguf"
 mmproj_file = "mmproj-model-f16.gguf"
 projector_type = "adapter"
 category = "general-small-vlm"
-status = "not-yet-tested"
-notes = "2B, Zhipu's edge/on-device-targeted VLM line."
+status = "smoke-tested-ok"
+notes = """
+2B, Zhipu's edge/on-device-targeted VLM line.
+SMOKE TEST (2026-07-11, --smoke, 2 images): loads and runs cleanly (projector
+"adapter" accepted). Passed 1/2 smoke images outright; the other miss was a
+summarize-in-prose failure ("cereal, with 1 cup of milk per serving, provides 25% of
+the Daily Value...") rather than verbatim transcription — similar in spirit to
+SmolVLM's captioning tendency but far less severe (this model got a real image
+outright right, SmolVLM never did). Worth the full run.
+"""

--- a/nutrition-fact-labeller/scripts/fetch-model.sh
+++ b/nutrition-fact-labeller/scripts/fetch-model.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Downloads a model + mmproj GGUF pair listed in ../models.toml into models/<key>/.
+# Usage: ./scripts/fetch-model.sh <key> [models-dir]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CRATE_DIR="$(dirname "$SCRIPT_DIR")"
+MANIFEST="$CRATE_DIR/models.toml"
+
+KEY="${1:?Usage: fetch-model.sh <key> [models-dir]}"
+MODELS_DIR="${2:-$CRATE_DIR/models}"
+
+read -r HF_REPO MODEL_FILE MMPROJ_FILE < <(python3 - "$MANIFEST" "$KEY" <<'PYEOF'
+import sys, tomllib
+manifest_path, key = sys.argv[1], sys.argv[2]
+with open(manifest_path, "rb") as f:
+    data = tomllib.load(f)
+entry = data.get("models", {}).get(key)
+if entry is None:
+    sys.exit(f"No [models.{key}] entry in {manifest_path}")
+print(entry["hf_repo"], entry["model_file"], entry["mmproj_file"])
+PYEOF
+)
+
+DEST="$MODELS_DIR/$KEY"
+mkdir -p "$DEST"
+
+for FILE in "$MODEL_FILE" "$MMPROJ_FILE"; do
+    OUT="$DEST/$FILE"
+    if [ -f "$OUT" ]; then
+        echo "already have $OUT, skipping"
+        continue
+    fi
+    URL="https://huggingface.co/$HF_REPO/resolve/main/$FILE"
+    echo "downloading $URL -> $OUT"
+    curl -sSL -o "$OUT" "$URL"
+done
+
+echo "$KEY ready:"
+echo "  model:  $DEST/$MODEL_FILE"
+echo "  mmproj: $DEST/$MMPROJ_FILE"

--- a/nutrition-fact-labeller/scripts/run-eval.sh
+++ b/nutrition-fact-labeller/scripts/run-eval.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Runs both eval harnesses (full-JSON and OCR-only) against a model listed in
+# ../models.toml. Fetches the model first if it isn't already downloaded.
+#
+# Usage:
+#   ./scripts/run-eval.sh <key>            # full 33-image eval, both harnesses
+#   ./scripts/run-eval.sh <key> --smoke    # 2-image smoke test only (verify it runs)
+#   ./scripts/run-eval.sh <key> --smoke N  # smoke test with N images instead of 2
+#
+# Model dir defaults to ../models/<key>/; override with MODELS_DIR env var.
+# Threads default to 4; override with THREADS env var.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CRATE_DIR="$(dirname "$SCRIPT_DIR")"
+MANIFEST="$CRATE_DIR/models.toml"
+
+KEY="${1:?Usage: run-eval.sh <key> [--smoke [N]]}"
+shift || true
+
+SMOKE=0
+LIMIT=2
+if [ "${1:-}" = "--smoke" ]; then
+    SMOKE=1
+    if [ "${2:-}" != "" ] && [ "${2:-}" != "--smoke" ]; then
+        LIMIT="$2"
+    fi
+fi
+
+MODELS_DIR="${MODELS_DIR:-$CRATE_DIR/models}"
+THREADS="${THREADS:-4}"
+
+"$SCRIPT_DIR/fetch-model.sh" "$KEY" "$MODELS_DIR"
+
+read -r DISPLAY_NAME MODEL_FILE MMPROJ_FILE < <(python3 - "$MANIFEST" "$KEY" <<'PYEOF'
+import sys, tomllib
+manifest_path, key = sys.argv[1], sys.argv[2]
+with open(manifest_path, "rb") as f:
+    data = tomllib.load(f)
+entry = data["models"][key]
+print(entry["display_name"], entry["model_file"], entry["mmproj_file"])
+PYEOF
+)
+
+MODEL_PATH="$MODELS_DIR/$KEY/$MODEL_FILE"
+MMPROJ_PATH="$MODELS_DIR/$KEY/$MMPROJ_FILE"
+
+cd "$CRATE_DIR"
+echo "Building vlm_benchmark and vlm_ocr_benchmark (release)..."
+cargo build --release --bin vlm_benchmark --bin vlm_ocr_benchmark
+
+LIMIT_ARGS=()
+if [ "$SMOKE" = "1" ]; then
+    LIMIT_ARGS=(--limit "$LIMIT")
+    echo "=== SMOKE TEST ($LIMIT image(s)) — verifying $DISPLAY_NAME loads and runs ==="
+else
+    echo "=== FULL EVAL (33 images) — $DISPLAY_NAME ==="
+fi
+
+echo
+echo "--- vlm_benchmark (full JSON extraction) ---"
+./target/release/vlm_benchmark \
+    --model "$MODEL_PATH" --mmproj "$MMPROJ_PATH" \
+    --model-name "$DISPLAY_NAME" \
+    --threads "$THREADS" \
+    "${LIMIT_ARGS[@]}"
+
+echo
+echo "--- vlm_ocr_benchmark (OCR-only + resilient parser) ---"
+./target/release/vlm_ocr_benchmark \
+    --model "$MODEL_PATH" --mmproj "$MMPROJ_PATH" \
+    --model-name "${DISPLAY_NAME}-ocr" \
+    --threads "$THREADS" \
+    "${LIMIT_ARGS[@]}"

--- a/nutrition-fact-labeller/src/bin/vlm_benchmark.rs
+++ b/nutrition-fact-labeller/src/bin/vlm_benchmark.rs
@@ -30,6 +30,12 @@ struct Args {
     /// Number of CPU threads for inference.
     #[arg(long, default_value_t = 4)]
     threads: i32,
+
+    /// Only run the first N test cases (e.g. --limit 2 for a quick smoke test that a
+    /// model loads and produces output, without running the full suite). Baseline
+    /// comparison is skipped when this is set, since it's only meaningful over all 33.
+    #[arg(long)]
+    limit: Option<usize>,
 }
 
 const BASELINE_PASS: usize = 9;
@@ -88,8 +94,13 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("Provide at least one --model / --mmproj pair");
     }
 
-    let cases = load_test_cases(&args.csv);
-    println!("Loaded {} test cases", cases.len());
+    let mut cases = load_test_cases(&args.csv);
+    if let Some(limit) = args.limit {
+        cases.truncate(limit);
+        println!("Loaded {} test cases (--limit {limit}: smoke test, not a full eval)", cases.len());
+    } else {
+        println!("Loaded {} test cases", cases.len());
+    }
 
     let mut results: Vec<BenchResult> = Vec::new();
 
@@ -118,16 +129,22 @@ fn main() -> anyhow::Result<()> {
     println!("\n{}", "─".repeat(55));
     println!("{:<32} {:>5} {:>5}  {}", "Model", "Pass", "Fail", "Score");
     println!("{}", "─".repeat(55));
-    println!(
-        "{:<32} {:>5} {:>5}  {}/{} (baseline)",
-        "PaddleOCR",
-        BASELINE_PASS,
-        BASELINE_TOTAL - BASELINE_PASS,
-        BASELINE_PASS,
-        BASELINE_TOTAL,
-    );
+    if args.limit.is_some() {
+        println!("(baseline comparison skipped: --limit was set, this isn't a full run)");
+    } else {
+        println!(
+            "{:<32} {:>5} {:>5}  {}/{} (baseline)",
+            "PaddleOCR",
+            BASELINE_PASS,
+            BASELINE_TOTAL - BASELINE_PASS,
+            BASELINE_PASS,
+            BASELINE_TOTAL,
+        );
+    }
     for r in &results {
-        let vs_baseline = if r.pass > BASELINE_PASS {
+        let vs_baseline = if args.limit.is_some() {
+            String::new()
+        } else if r.pass > BASELINE_PASS {
             format!(" ▲ +{}", r.pass - BASELINE_PASS)
         } else if r.pass < BASELINE_PASS {
             format!(" ▼ -{}", BASELINE_PASS - r.pass)

--- a/nutrition-fact-labeller/src/bin/vlm_ocr_benchmark.rs
+++ b/nutrition-fact-labeller/src/bin/vlm_ocr_benchmark.rs
@@ -36,6 +36,12 @@ struct Args {
     /// Number of CPU threads for inference.
     #[arg(long, default_value_t = 4)]
     threads: i32,
+
+    /// Only run the first N test cases (e.g. --limit 2 for a quick smoke test that a
+    /// model loads and produces output, without running the full suite). Baseline
+    /// comparison is skipped when this is set, since it's only meaningful over all 33.
+    #[arg(long)]
+    limit: Option<usize>,
 }
 
 const BASELINE_PASS: usize = 9;
@@ -44,8 +50,13 @@ const BASELINE_TOTAL: usize = 33;
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    let cases = load_test_cases(&args.csv);
-    println!("Loaded {} test cases", cases.len());
+    let mut cases = load_test_cases(&args.csv);
+    if let Some(limit) = args.limit {
+        cases.truncate(limit);
+        println!("Loaded {} test cases (--limit {limit}: smoke test, not a full eval)", cases.len());
+    } else {
+        println!("Loaded {} test cases", cases.len());
+    }
 
     println!("\nLoading [{}] from {}", args.model_name, args.model.display());
     let backend = LlavaBackend::new(&args.model_name, &args.model, &args.mmproj, args.threads)?;
@@ -86,15 +97,21 @@ fn main() -> anyhow::Result<()> {
     println!("\n{}", "─".repeat(55));
     println!("{:<32} {:>5} {:>5}  {}", "Model", "Pass", "Fail", "Score");
     println!("{}", "─".repeat(55));
-    println!(
-        "{:<32} {:>5} {:>5}  {}/{} (baseline)",
-        "PaddleOCR",
-        BASELINE_PASS,
-        BASELINE_TOTAL - BASELINE_PASS,
-        BASELINE_PASS,
-        BASELINE_TOTAL,
-    );
-    let vs_baseline = if pass > BASELINE_PASS {
+    if args.limit.is_some() {
+        println!("(baseline comparison skipped: --limit was set, this isn't a full run)");
+    } else {
+        println!(
+            "{:<32} {:>5} {:>5}  {}/{} (baseline)",
+            "PaddleOCR",
+            BASELINE_PASS,
+            BASELINE_TOTAL - BASELINE_PASS,
+            BASELINE_PASS,
+            BASELINE_TOTAL,
+        );
+    }
+    let vs_baseline = if args.limit.is_some() {
+        String::new()
+    } else if pass > BASELINE_PASS {
         format!(" ▲ +{}", pass - BASELINE_PASS)
     } else if pass < BASELINE_PASS {
         format!(" ▼ -{}", BASELINE_PASS - pass)

--- a/nutrition-fact-labeller/src/bin/vlm_ocr_benchmark.rs
+++ b/nutrition-fact-labeller/src/bin/vlm_ocr_benchmark.rs
@@ -1,0 +1,123 @@
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+use nutrition_fact_labeller::parsing::parse_facts_from_lines;
+use nutrition_fact_labeller::vlm::llava::LlavaBackend;
+use nutrition_fact_labeller::{load_test_cases, ParsedNutritionFacts};
+
+/// Benchmarks a VLM used purely as an OCR engine: image -> transcribed text lines ->
+/// the same regex/spellcheck parser (`parsing::parse_facts_from_lines`) that the
+/// PaddleOCR backend runs on its detected text regions. This isolates "can the VLM read
+/// the label" from "can the VLM emit well-typed structured JSON" (see vlm_benchmark.rs
+/// for the latter).
+#[derive(Parser)]
+#[command(about = "Benchmark a VLM as an OCR-only text source for the nutrition fact labeller test suite")]
+struct Args {
+    /// Path to a GGUF model file.
+    #[arg(long)]
+    model: PathBuf,
+
+    /// Path to the corresponding mmproj GGUF file.
+    #[arg(long)]
+    mmproj: PathBuf,
+
+    /// Display name for the model.
+    #[arg(long, default_value = "vlm-ocr")]
+    model_name: String,
+
+    /// Path to test_cases.csv.
+    #[arg(long, default_value = "test_cases.csv")]
+    csv: String,
+
+    /// Directory containing test images.
+    #[arg(long, default_value = "images")]
+    images_dir: PathBuf,
+
+    /// Number of CPU threads for inference.
+    #[arg(long, default_value_t = 4)]
+    threads: i32,
+}
+
+const BASELINE_PASS: usize = 9;
+const BASELINE_TOTAL: usize = 33;
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    let cases = load_test_cases(&args.csv);
+    println!("Loaded {} test cases", cases.len());
+
+    println!("\nLoading [{}] from {}", args.model_name, args.model.display());
+    let backend = LlavaBackend::new(&args.model_name, &args.model, &args.mmproj, args.threads)?;
+
+    println!("Running OCR-only inference on {} images...", cases.len());
+    let mut pass = 0;
+    let mut passing_files: Vec<String> = Vec::new();
+    let mut failing_files: Vec<String> = Vec::new();
+
+    for (filename, expected) in &cases {
+        let image_path: &Path = &args.images_dir.join(filename);
+        match backend.transcribe(image_path) {
+            Ok(text) => {
+                let lines: Vec<&str> = text
+                    .lines()
+                    .map(|l| l.trim())
+                    .filter(|l| !l.is_empty())
+                    .collect();
+                let actual: ParsedNutritionFacts = parse_facts_from_lines(&lines);
+                if &actual == expected {
+                    pass += 1;
+                    passing_files.push(filename.clone());
+                } else {
+                    eprintln!("  FAIL {filename}");
+                    eprintln!("    transcribed: {lines:?}");
+                    eprintln!("    got:      {actual:?}");
+                    eprintln!("    expected: {expected:?}");
+                    failing_files.push(filename.clone());
+                }
+            }
+            Err(e) => {
+                eprintln!("  ERROR {filename}: {e}");
+                failing_files.push(filename.clone());
+            }
+        }
+    }
+
+    println!("\n{}", "─".repeat(55));
+    println!("{:<32} {:>5} {:>5}  {}", "Model", "Pass", "Fail", "Score");
+    println!("{}", "─".repeat(55));
+    println!(
+        "{:<32} {:>5} {:>5}  {}/{} (baseline)",
+        "PaddleOCR",
+        BASELINE_PASS,
+        BASELINE_TOTAL - BASELINE_PASS,
+        BASELINE_PASS,
+        BASELINE_TOTAL,
+    );
+    let vs_baseline = if pass > BASELINE_PASS {
+        format!(" ▲ +{}", pass - BASELINE_PASS)
+    } else if pass < BASELINE_PASS {
+        format!(" ▼ -{}", BASELINE_PASS - pass)
+    } else {
+        " = tie".to_string()
+    };
+    println!(
+        "{:<32} {:>5} {:>5}  {}/{}{}",
+        args.model_name,
+        pass,
+        cases.len() - pass,
+        pass,
+        cases.len(),
+        vs_baseline,
+    );
+    println!("{}", "─".repeat(55));
+
+    if !passing_files.is_empty() {
+        println!("\n[{}] passing ({}/{}):", args.model_name, pass, cases.len());
+        for f in &passing_files {
+            println!("  ✓ {f}");
+        }
+    }
+
+    Ok(())
+}

--- a/nutrition-fact-labeller/src/lib.rs
+++ b/nutrition-fact-labeller/src/lib.rs
@@ -2,6 +2,8 @@ use std::path::Path;
 
 use serde_derive::{Deserialize, Serialize};
 
+pub mod parsing;
+pub mod spellcheck;
 pub mod vlm;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]

--- a/nutrition-fact-labeller/src/main.rs
+++ b/nutrition-fact-labeller/src/main.rs
@@ -13,9 +13,9 @@ use oar_ocr::utils::image::dynamic_to_rgb;
 use oar_ocr::core::config::onnx::{OrtSessionConfig, OrtExecutionProvider, OrtGraphOptimizationLevel};
 use serde_derive::{Deserialize, Serialize};
 use nutrition_fact_labeller::{ParsedNutritionFacts, VlmBackend};
+use nutrition_fact_labeller::parsing::parse_facts_from_lines;
 use nutrition_fact_labeller::vlm::llava::LlavaBackend;
 use nutrition_fact_labeller::vlm::openrouter::{LlmApiBackend, DEFAULT_MODEL};
-mod spellcheck;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct MyTextRegion {
@@ -247,156 +247,17 @@ where
 }
 fn parse_facts_from_regions(regions: Vec<MyTextRegion>) -> ParsedNutritionFacts {
     let texts: Vec<&str> = regions.iter().map(|x| x.text.as_str()).collect();
-    let dictionary = spellcheck::dictionary();
-    let spellchecked: Vec<String> = timeit("spellchecking", || {
-        texts.iter().map(|s| s.split_whitespace().map(|w: &str| {
-            spellcheck::correction(&w, &dictionary)
-        }).collect::<Vec<&str>>().join(" ")).collect()
-    });
-    debug!("{:#?}", std::iter::zip(texts.clone(), spellchecked.clone()).collect::<Vec<(&str, String)>>());
-    return parse_facts(spellchecked.iter().map(|s| s.as_str()).collect());
-}
-
-use regex::Regex;
-
-#[derive(Debug, Serialize)]
-struct LabelledValue {
-    label: String,
-    value: String,
-    unit: Option<String>,
-}
-
-// Helper to find a value by label predicate
-fn find_labelled_value<T, F, C>(
-    xs: &[LabelledValue],
-    flabel: F,
-    convert: C,
-) -> Option<T>
-where
-    F: Fn(&str) -> bool,
-    C: Fn(&str) -> Option<T>,
-{
-    xs.iter()
-        .find(|x| flabel(&x.label))
-        .and_then(|x| convert(&x.value))
-}
-
-// Label matchers
-fn starts_with<'a>(target: &'a str) -> impl Fn(&str) -> bool + 'a {
-    move |label: &str| label.starts_with(target)
-}
-
-fn ends_with<'a>(target: &'a str) -> impl Fn(&str) -> bool + 'a {
-    move |label: &str| label.ends_with(target)
-}
-
-fn contains<'a>(target: &'a str) -> impl Fn(&str) -> bool + 'a {
-    move |label: &str| label.contains(target)
-}
-
-pub fn parse_facts(content: Vec<&str>) -> ParsedNutritionFacts {
-    // sometimes "xg" is read as "x9"
-    let re_g = Regex::new(r"(?i)([\do]+(?:\.[\do]+)?)(g|mg|9)").unwrap();
-    let re_servings = Regex::new(r"(\d+\.?\d*) servings per container").unwrap();
-
-    let mut results: Vec<LabelledValue> = Vec::new();
-
-    for i in 0..content.len().saturating_sub(1) {
-        let line = content[i];
-
-        // Match "123g" or "123mg"
-        if let Some(caps) = re_g.captures(line) {
-            results.push(LabelledValue {
-                label: line.to_lowercase().trim().to_string(),
-                // sometimes 0 is read as O, so we allow it in the regex above and replace it back
-                value: caps[1].to_string().replace("O", "0").replace("o", "0"),
-                unit: Some(caps[2].to_string()),
-            });
-            continue;
-        }
-
-        // sometimes we get including xg / added sugars broken up
-        if content[i].eq_ignore_ascii_case("added sugars") {
-            if let Some(lvalue) = results.pop() {
-                let previous_label = lvalue.label;
-                results.push(LabelledValue {
-                    label: format!("{previous_label} added sugars"),
-                    value: lvalue.value,
-                    unit: lvalue.unit
-                });
-            }
-            continue;
-        }
-
-        // sometimes we get serving size _after_ the labelled value
-        if content[i].eq_ignore_ascii_case("serving size") {
-            if let Some(lvalue) = results.pop() {
-                let previous_label = lvalue.label;
-                results.push(LabelledValue {
-                    label: format!("serving size {previous_label}"),
-                    value: lvalue.value,
-                    unit: lvalue.unit
-                });
-            }
-            continue;
-        }
-
-        // Match "X servings per container"
-        if let Some(caps) = re_servings.captures(line) {
-            results.push(LabelledValue {
-                label: line.to_lowercase().replace(".", ""),
-                value: caps[1].to_string(),
-                unit: None,
-            });
-        }
-    }
-
-    for i in 0..content.len().saturating_sub(1) {
-        // Match "Calories <number>" using zip(content, content[1:])
-        if content[i].eq_ignore_ascii_case("calories") {
-            // did we get Calories, N or N, Calories?
-            let is_after: bool = content[i + 1].chars().all(|c| c.is_numeric());
-            if is_after {
-                let value = content[i + 1];
-                results.push(LabelledValue {
-                    label: format!("{} {}", content[i], value).to_lowercase(),
-                    value: value.to_string(),
-                    unit: None,
-                });
-            } else {
-                // include an inverse pair in case we get 130, Calories
-                let value = content[i - 1];
-                results.push(LabelledValue {
-                    label: format!("{} {}", content[i], value).to_lowercase(),
-                    value: value.to_string(),
-                    unit: None,
-                });
-            }
-            continue;
-        }
-    }
-
-    debug!("{:#?}", results);
-
-    ParsedNutritionFacts {
-        servings_per_container: find_labelled_value(&results, ends_with("servings per container"), |s| s.parse::<f64>().ok()),
-        serving_size_grams: find_labelled_value(&results, starts_with("serving size"), |s| s.parse::<f64>().ok()),
-        calories: find_labelled_value(&results, starts_with("calories"), |s| s.parse::<i32>().ok()),
-        total_fat_grams: find_labelled_value(&results, starts_with("total fat"), |s| s.parse::<f64>().ok()),
-        cholesterol_mg: find_labelled_value(&results, starts_with("cholesterol"), |s| s.parse::<f64>().ok()),
-        sodium_mg: find_labelled_value(&results, starts_with("sodium"), |s| s.parse::<f64>().ok()),
-        total_carbohydrates_g: find_labelled_value(&results, starts_with("total carbohydrate"), |s| s.parse::<f64>().ok()),
-        dietary_fiber_g: find_labelled_value(&results, starts_with("dietary fiber"), |s| s.parse::<f64>().ok()),
-        total_sugars_g: find_labelled_value(&results, starts_with("total sugars"), |s| s.parse::<f64>().ok()),
-        added_sugars_g: find_labelled_value(&results, contains("added sugars"), |s| s.parse::<f64>().ok()),
-        protein_g: find_labelled_value(&results, starts_with("protein"), |s| s.parse::<f64>().ok()),
-    }
+    let actual = timeit("spellchecking + parsing", || parse_facts_from_lines(&texts));
+    debug!("{:#?}", texts);
+    actual
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nutrition_fact_labeller::spellcheck;
     use pretty_assertions::assert_eq;
+    use regex::Regex;
     use std::fs;
     use std::path::Path;
 

--- a/nutrition-fact-labeller/src/parsing.rs
+++ b/nutrition-fact-labeller/src/parsing.rs
@@ -140,9 +140,110 @@ pub fn parse_facts(content: Vec<&str>) -> ParsedNutritionFacts {
     }
 }
 
+/// Finds the number (by character distance) nearest any occurrence of a label phrase,
+/// within `max_gap` characters, regardless of whether the number comes before the label
+/// ("8 servings per container", "Includes 3g Added Sugars") or after it ("Calories 110",
+/// "Total Fat 4g"). When `require_unit` is set, only numbers directly followed by a
+/// weight unit (g/mg, tolerating a misread "g" as "9") are considered candidates — this
+/// is what lets `serving_size_grams` skip over an unrelated bare number like the "1" in
+/// "Serving size 1 bar (36g)" to find the real "36g", and lets `added_sugars_g` prefer
+/// the immediately adjacent "9g" over the farther "10g" in "Total Sugars 10g Includes 9g
+/// Added Sugars 17%" — the *nearest* valid candidate wins, not the first one found.
+fn find_near(text: &str, label_pattern: &str, max_gap: usize, require_unit: bool) -> Option<f64> {
+    let label_re = Regex::new(&format!(r"(?i)\b{label_pattern}")).ok()?;
+    let num_re = if require_unit {
+        Regex::new(r"(?i)([\do]+(?:\.[\do]+)?)\s*(?:g|mg|9)\b").ok()?
+    } else {
+        Regex::new(r"([\do]+(?:\.[\do]+)?)").ok()?
+    };
+
+    let label_spans: Vec<(usize, usize)> = label_re.find_iter(text).map(|m| (m.start(), m.end())).collect();
+    if label_spans.is_empty() {
+        return None;
+    }
+
+    let mut best: Option<(usize, f64)> = None;
+    for cap in num_re.captures_iter(text) {
+        let m = cap.get(0).unwrap();
+        // The "o" in "[\do]" tolerates a digit OCR-misread as the letter O, but a run
+        // with *no* real digit at all is just an ordinary word (e.g. the "o" inside
+        // "calories" or "sodium" themselves) — require at least one genuine digit so
+        // label words don't get treated as zero-distance number candidates for
+        // themselves.
+        if !cap[1].chars().any(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        let Some(value) = normalize_number(&cap[1]) else { continue };
+        for &(lstart, lend) in &label_spans {
+            let dist = if m.start() >= lend {
+                m.start() - lend
+            } else if lstart >= m.end() {
+                lstart - m.end()
+            } else {
+                0
+            };
+            if dist <= max_gap && best.is_none_or(|(bd, _)| dist < bd) {
+                best = Some((dist, value));
+            }
+        }
+    }
+    best.map(|(_, v)| v)
+}
+
+fn normalize_number(s: &str) -> Option<f64> {
+    s.replace(['O', 'o'], "0").parse::<f64>().ok()
+}
+
+/// Fills in any fields the primary line-based parser above left as `None` by scanning
+/// the full transcription text (all lines joined, ignoring where the line breaks fell)
+/// for each label's nearest number. `parse_facts` assumes something close to
+/// one-label-per-line, which mostly holds for PaddleOCR's per-detected-box output but
+/// not for a VLM transcription, which may merge several label/value pairs onto one
+/// line or even collapse the whole label into a single run-on paragraph. This pass is
+/// purely additive — it only ever fills a `None`, never overrides a value the primary
+/// parser already found — so it can't regress the primary parser's existing behavior.
+fn fill_gaps_from_blob(mut facts: ParsedNutritionFacts, blob: &str) -> ParsedNutritionFacts {
+    if facts.servings_per_container.is_none() {
+        facts.servings_per_container = find_near(blob, r"servings\s*per\s*container", 20, false);
+    }
+    if facts.serving_size_grams.is_none() {
+        facts.serving_size_grams = find_near(blob, r"serving\s*size", 25, true);
+    }
+    if facts.calories.is_none() {
+        facts.calories = find_near(blob, r"calories\b", 20, false).map(|n| n as i32);
+    }
+    if facts.total_fat_grams.is_none() {
+        facts.total_fat_grams = find_near(blob, r"total\s*fat\b", 20, true);
+    }
+    if facts.cholesterol_mg.is_none() {
+        facts.cholesterol_mg = find_near(blob, r"cholesterol\b", 20, true);
+    }
+    if facts.sodium_mg.is_none() {
+        facts.sodium_mg = find_near(blob, r"sodium\b", 20, true);
+    }
+    if facts.total_carbohydrates_g.is_none() {
+        facts.total_carbohydrates_g = find_near(blob, r"total\s*carbohydrate", 20, true);
+    }
+    if facts.dietary_fiber_g.is_none() {
+        facts.dietary_fiber_g = find_near(blob, r"dietary\s*fiber", 20, true);
+    }
+    if facts.total_sugars_g.is_none() {
+        facts.total_sugars_g = find_near(blob, r"total\s*sugars", 20, true);
+    }
+    if facts.added_sugars_g.is_none() {
+        facts.added_sugars_g = find_near(blob, r"added\s*sugars", 25, true);
+    }
+    if facts.protein_g.is_none() {
+        facts.protein_g = find_near(blob, r"protein\b", 20, true);
+    }
+    facts
+}
+
 /// Spellchecks each word of each line against the fixed nutrition-label dictionary, then
-/// parses the corrected lines with `parse_facts`. Shared by the PaddleOCR backend (one line
-/// per detected text region) and VLM-transcription backends (one line per transcribed line).
+/// parses the corrected lines with `parse_facts`, and finally fills in any fields that
+/// left with a blob-wide scan (see `fill_gaps_from_blob`) so the result is resilient to
+/// however many lines the caller actually provided — from PaddleOCR's many short
+/// per-detection-box lines down to a VLM's single run-on paragraph.
 pub fn parse_facts_from_lines(lines: &[&str]) -> ParsedNutritionFacts {
     let dictionary = spellcheck::dictionary();
     let spellchecked: Vec<String> = lines
@@ -154,5 +255,120 @@ pub fn parse_facts_from_lines(lines: &[&str]) -> ParsedNutritionFacts {
                 .join(" ")
         })
         .collect();
-    parse_facts(spellchecked.iter().map(|s| s.as_str()).collect())
+    let refs: Vec<&str> = spellchecked.iter().map(|s| s.as_str()).collect();
+    let facts = parse_facts(refs.clone());
+    let blob = refs.join(" ");
+    fill_gaps_from_blob(facts, &blob)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    // Real MiniCPM-V 4.6 transcriptions captured from a vlm_ocr_benchmark run
+    // (see eval-results/2026-07-11-minicpm-v-4.6-ocr-only.md), used as fixtures so the
+    // blob-fallback fix can be verified without re-running the VLM.
+
+    #[test]
+    fn merged_calories_line_is_recovered() {
+        // IMG_5437_1200.png: every field transcribed onto its own line except
+        // "Calories 110", which the primary line-based parser can't see because it
+        // requires "Calories" and its number on separate lines.
+        let lines = vec![
+            "Nutrition Facts",
+            "About 8 servings per container",
+            "Serving size 1/3 cup (30g)",
+            "Calories 110",
+            "Amount per serving",
+            "Calories 110",
+            "% Daily Value",
+            "Total Fat 1.5g 2%",
+            "Saturated Fat 0g 0%",
+            "Trans Fat 0g",
+            "Cholesterol 0mg 0%",
+            "Sodium 350mg 15%",
+            "Total Carbohydrate 20g 7%",
+            "Dietary Fiber <1g 3%",
+            "Total Sugars 0g",
+            "Includes 0g Added Sugars 0%",
+            "Protein 3g",
+            "Vitamin D 0mcg %",
+        ];
+        let actual = parse_facts_from_lines(&lines);
+        assert_eq!(
+            actual,
+            ParsedNutritionFacts {
+                servings_per_container: Some(8.0),
+                serving_size_grams: Some(30.0),
+                calories: Some(110),
+                total_fat_grams: Some(1.5),
+                cholesterol_mg: Some(0.0),
+                sodium_mg: Some(350.0),
+                total_carbohydrates_g: Some(20.0),
+                dietary_fiber_g: Some(1.0),
+                total_sugars_g: Some(0.0),
+                added_sugars_g: Some(0.0),
+                protein_g: Some(3.0),
+            }
+        );
+    }
+
+    #[test]
+    fn fully_collapsed_transcription_is_recovered() {
+        // IMG_5423_1200.png: MiniCPM ignored the "one line per line" instruction and
+        // returned the entire label (twice over, plus ingredients) as a single line.
+        let lines = vec![
+            "Nutrition Facts 12 servings per container Serving size 1 bar (36g) \
+             Calories 140 Total Fat 5g % Daily Value 6% Saturated Fat 1g 6% Trans Fat 0g \
+             Cholesterol 0mg 0% Sodium 105mg 5% Total Carbohydrate 24g 9% Dietary Fiber 2g 10% \
+             Total Sugars 10g Includes 9g Added Sugars 17% Protein 2g Vit. D 0mcg Calcium 15mg 2% \
+             Iron 1mg 6%. Potas. 92mg 2% Vit. E 8% Phosphorus 4% Magnesium 6% *t the % Daily Value \
+             tells you how much a nutrient in a day is used for a general nutrition advice.",
+        ];
+        let actual = parse_facts_from_lines(&lines);
+        assert_eq!(
+            actual,
+            ParsedNutritionFacts {
+                servings_per_container: Some(12.0),
+                serving_size_grams: Some(36.0),
+                calories: Some(140),
+                total_fat_grams: Some(5.0),
+                cholesterol_mg: Some(0.0),
+                sodium_mg: Some(105.0),
+                total_carbohydrates_g: Some(24.0),
+                dietary_fiber_g: Some(2.0),
+                total_sugars_g: Some(10.0),
+                added_sugars_g: Some(9.0),
+                protein_g: Some(2.0),
+            }
+        );
+    }
+
+    #[test]
+    fn does_not_regress_well_formed_line_per_entry_input() {
+        // A tidy, one-value-per-line PaddleOCR-style input (the common case) should
+        // still parse correctly with the fallback pass in place.
+        let lines = vec![
+            "5 servings per container",
+            "serving size",
+            "30",
+            "calories",
+            "120",
+            "total fat 4g",
+            "cholesterol 0mg",
+            "sodium 85mg",
+            "total carbohydrate 20g",
+            "dietary fiber 2g",
+            "total sugars 6g",
+            "added sugars",
+            "protein 2g",
+            "vitamin d 0mcg",
+        ];
+        let actual = parse_facts_from_lines(&lines);
+        assert_eq!(actual.servings_per_container, Some(5.0));
+        assert_eq!(actual.calories, Some(120));
+        assert_eq!(actual.total_fat_grams, Some(4.0));
+        assert_eq!(actual.protein_g, Some(2.0));
+    }
 }

--- a/nutrition-fact-labeller/src/parsing.rs
+++ b/nutrition-fact-labeller/src/parsing.rs
@@ -1,0 +1,158 @@
+use regex::Regex;
+
+use crate::spellcheck;
+use crate::ParsedNutritionFacts;
+
+#[derive(Debug)]
+struct LabelledValue {
+    label: String,
+    value: String,
+    unit: Option<String>,
+}
+
+// Helper to find a value by label predicate
+fn find_labelled_value<T, F, C>(
+    xs: &[LabelledValue],
+    flabel: F,
+    convert: C,
+) -> Option<T>
+where
+    F: Fn(&str) -> bool,
+    C: Fn(&str) -> Option<T>,
+{
+    xs.iter()
+        .find(|x| flabel(&x.label))
+        .and_then(|x| convert(&x.value))
+}
+
+// Label matchers
+fn starts_with<'a>(target: &'a str) -> impl Fn(&str) -> bool + 'a {
+    move |label: &str| label.starts_with(target)
+}
+
+fn ends_with<'a>(target: &'a str) -> impl Fn(&str) -> bool + 'a {
+    move |label: &str| label.ends_with(target)
+}
+
+fn contains<'a>(target: &'a str) -> impl Fn(&str) -> bool + 'a {
+    move |label: &str| label.contains(target)
+}
+
+/// Parses lines of label text (e.g. one per detected OCR text region, or one per
+/// transcribed line from a VLM) into structured nutrition facts using label/value
+/// regex matching. Does not spellcheck — see `parse_facts_from_lines` for that.
+pub fn parse_facts(content: Vec<&str>) -> ParsedNutritionFacts {
+    // sometimes "xg" is read as "x9"
+    let re_g = Regex::new(r"(?i)([\do]+(?:\.[\do]+)?)(g|mg|9)").unwrap();
+    let re_servings = Regex::new(r"(\d+\.?\d*) servings per container").unwrap();
+
+    let mut results: Vec<LabelledValue> = Vec::new();
+
+    for i in 0..content.len().saturating_sub(1) {
+        let line = content[i];
+
+        // Match "123g" or "123mg"
+        if let Some(caps) = re_g.captures(line) {
+            results.push(LabelledValue {
+                label: line.to_lowercase().trim().to_string(),
+                // sometimes 0 is read as O, so we allow it in the regex above and replace it back
+                value: caps[1].to_string().replace("O", "0").replace("o", "0"),
+                unit: Some(caps[2].to_string()),
+            });
+            continue;
+        }
+
+        // sometimes we get including xg / added sugars broken up
+        if content[i].eq_ignore_ascii_case("added sugars") {
+            if let Some(lvalue) = results.pop() {
+                let previous_label = lvalue.label;
+                results.push(LabelledValue {
+                    label: format!("{previous_label} added sugars"),
+                    value: lvalue.value,
+                    unit: lvalue.unit
+                });
+            }
+            continue;
+        }
+
+        // sometimes we get serving size _after_ the labelled value
+        if content[i].eq_ignore_ascii_case("serving size") {
+            if let Some(lvalue) = results.pop() {
+                let previous_label = lvalue.label;
+                results.push(LabelledValue {
+                    label: format!("serving size {previous_label}"),
+                    value: lvalue.value,
+                    unit: lvalue.unit
+                });
+            }
+            continue;
+        }
+
+        // Match "X servings per container"
+        if let Some(caps) = re_servings.captures(line) {
+            results.push(LabelledValue {
+                label: line.to_lowercase().replace(".", ""),
+                value: caps[1].to_string(),
+                unit: None,
+            });
+        }
+    }
+
+    for i in 0..content.len().saturating_sub(1) {
+        // Match "Calories <number>" using zip(content, content[1:])
+        if content[i].eq_ignore_ascii_case("calories") {
+            // did we get Calories, N or N, Calories?
+            let is_after: bool = content[i + 1].chars().all(|c| c.is_numeric());
+            if is_after {
+                let value = content[i + 1];
+                results.push(LabelledValue {
+                    label: format!("{} {}", content[i], value).to_lowercase(),
+                    value: value.to_string(),
+                    unit: None,
+                });
+            } else {
+                // include an inverse pair in case we get 130, Calories
+                let value = content[i - 1];
+                results.push(LabelledValue {
+                    label: format!("{} {}", content[i], value).to_lowercase(),
+                    value: value.to_string(),
+                    unit: None,
+                });
+            }
+            continue;
+        }
+    }
+
+    log::debug!("{:#?}", results);
+
+    ParsedNutritionFacts {
+        servings_per_container: find_labelled_value(&results, ends_with("servings per container"), |s| s.parse::<f64>().ok()),
+        serving_size_grams: find_labelled_value(&results, starts_with("serving size"), |s| s.parse::<f64>().ok()),
+        calories: find_labelled_value(&results, starts_with("calories"), |s| s.parse::<i32>().ok()),
+        total_fat_grams: find_labelled_value(&results, starts_with("total fat"), |s| s.parse::<f64>().ok()),
+        cholesterol_mg: find_labelled_value(&results, starts_with("cholesterol"), |s| s.parse::<f64>().ok()),
+        sodium_mg: find_labelled_value(&results, starts_with("sodium"), |s| s.parse::<f64>().ok()),
+        total_carbohydrates_g: find_labelled_value(&results, starts_with("total carbohydrate"), |s| s.parse::<f64>().ok()),
+        dietary_fiber_g: find_labelled_value(&results, starts_with("dietary fiber"), |s| s.parse::<f64>().ok()),
+        total_sugars_g: find_labelled_value(&results, starts_with("total sugars"), |s| s.parse::<f64>().ok()),
+        added_sugars_g: find_labelled_value(&results, contains("added sugars"), |s| s.parse::<f64>().ok()),
+        protein_g: find_labelled_value(&results, starts_with("protein"), |s| s.parse::<f64>().ok()),
+    }
+}
+
+/// Spellchecks each word of each line against the fixed nutrition-label dictionary, then
+/// parses the corrected lines with `parse_facts`. Shared by the PaddleOCR backend (one line
+/// per detected text region) and VLM-transcription backends (one line per transcribed line).
+pub fn parse_facts_from_lines(lines: &[&str]) -> ParsedNutritionFacts {
+    let dictionary = spellcheck::dictionary();
+    let spellchecked: Vec<String> = lines
+        .iter()
+        .map(|s| {
+            s.split_whitespace()
+                .map(|w: &str| spellcheck::correction(w, &dictionary))
+                .collect::<Vec<&str>>()
+                .join(" ")
+        })
+        .collect();
+    parse_facts(spellchecked.iter().map(|s| s.as_str()).collect())
+}

--- a/nutrition-fact-labeller/src/vlm/llava.rs
+++ b/nutrition-fact-labeller/src/vlm/llava.rs
@@ -13,7 +13,7 @@ use llama_cpp_2::mtmd::{mtmd_default_marker, MtmdBitmap, MtmdContext, MtmdContex
 use llama_cpp_2::sampling::LlamaSampler;
 
 use crate::{ParsedNutritionFacts, VlmBackend};
-use super::{extract_json, NUTRITION_PROMPT};
+use super::{extract_json, NUTRITION_PROMPT, OCR_TRANSCRIBE_PROMPT};
 
 /// A VLM backend for LLaVA-style GGUF models (moondream2, llava-phi3, etc.).
 /// Loads the model once and creates fresh contexts per inference call.
@@ -47,12 +47,11 @@ impl LlavaBackend {
     }
 }
 
-impl VlmBackend for LlavaBackend {
-    fn name(&self) -> &str {
-        &self.name
-    }
-
-    fn infer(&self, image_path: &Path) -> anyhow::Result<ParsedNutritionFacts> {
+impl LlavaBackend {
+    /// Runs the model on `image_path` with the given text prompt and returns the raw
+    /// generated text (up to 512 tokens, greedy sampling). Shared by `infer` (which
+    /// expects JSON back) and `transcribe` (which expects raw label text back).
+    fn generate(&self, image_path: &Path, prompt_text: &str) -> anyhow::Result<String> {
         let marker = mtmd_default_marker().to_string();
 
         // Load vision encoder
@@ -86,11 +85,8 @@ impl VlmBackend for LlavaBackend {
             .context("Failed to load image bitmap")?;
 
         // Build prompt: image marker + instruction
-        let prompt = format!("{marker}{NUTRITION_PROMPT}");
+        let prompt = format!("{marker}{prompt_text}");
 
-        // Try the model's built-in chat template; fall back to the Gemma 4 turn
-        // format if the embedded Jinja2 renderer can't handle it (e.g., Gemma 4's
-        // template uses features unsupported by llama.cpp's renderer).
         // Try the model's built-in chat template; fall back to raw prompt if the
         // embedded Jinja2 renderer can't handle it (e.g., Gemma 4's template uses
         // features unsupported by llama.cpp's renderer).
@@ -123,7 +119,7 @@ impl VlmBackend for LlavaBackend {
             .eval_chunks(&mtmd_ctx, &mut context, 0, 0, 1, true)
             .context("Failed to eval chunks")?;
 
-        // Decode (generate JSON output)
+        // Decode (generate output)
         let mut sampler = LlamaSampler::chain_simple([LlamaSampler::greedy()]);
         let mut output = String::new();
         let mut decoder = UTF_8.new_decoder();
@@ -145,6 +141,23 @@ impl VlmBackend for LlavaBackend {
             context.decode(&mut batch).context("decode failed")?;
         }
 
+        Ok(output)
+    }
+
+    /// Uses the model purely as an OCR engine: transcribes the label's visible text and
+    /// returns it raw (one line per line of output), without asking for or parsing JSON.
+    pub fn transcribe(&self, image_path: &Path) -> anyhow::Result<String> {
+        self.generate(image_path, OCR_TRANSCRIBE_PROMPT)
+    }
+}
+
+impl VlmBackend for LlavaBackend {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn infer(&self, image_path: &Path) -> anyhow::Result<ParsedNutritionFacts> {
+        let output = self.generate(image_path, NUTRITION_PROMPT)?;
         let json_str = extract_json(&output).unwrap_or(output.trim());
         serde_json::from_str::<ParsedNutritionFacts>(json_str)
             .with_context(|| format!("Failed to parse VLM JSON output:\n{output}"))

--- a/nutrition-fact-labeller/src/vlm/mod.rs
+++ b/nutrition-fact-labeller/src/vlm/mod.rs
@@ -15,6 +15,17 @@ pub const NUTRITION_PROMPT: &str =
      - Do NOT use null when the label shows 0. Use 0 instead.\n\
      No explanation. No markdown. No code blocks. JSON only.";
 
+/// Prompt for using a VLM purely as an OCR engine: transcribe the label's text
+/// verbatim, one line per line of output, with no interpretation. The output is
+/// meant to be fed into the same line-oriented regex parser (`parsing::parse_facts_from_lines`)
+/// that the PaddleOCR backend uses on its detected text regions.
+pub const OCR_TRANSCRIBE_PROMPT: &str =
+    "Transcribe every line of text visible on this nutrition facts label exactly as printed, \
+     top to bottom, one line of output per line of text on the label. \
+     Do not translate, summarize, reformat, or interpret the text. \
+     Do not add labels, explanations, JSON, or punctuation that isn't on the label. \
+     Output only the raw transcribed text.";
+
 /// Extract the first complete `{...}` block from a string.
 /// Handles models that prepend preamble text before the JSON.
 pub fn extract_json(s: &str) -> Option<&str> {


### PR DESCRIPTION
## Summary

Continues the nutrition-fact-labeller VLM eval work from PR #25 (MiniCPM-V 4.6 full-JSON
extraction). This PR:

- **Adds a second extraction strategy** (`vlm_ocr_benchmark`): use the VLM purely as an OCR
  engine, feeding its transcription through the same regex/spellcheck parser the PaddleOCR
  backend already uses (`parsing::parse_facts_from_lines`, moved out of `main.rs` into the shared
  library so it's reusable).
- **Makes that parser resilient** to how a VLM actually formats transcriptions (merged
  label/value lines, or a fully collapsed single-paragraph transcription) via an additive
  `fill_gaps_from_blob` fallback pass — this took MiniCPM-V 4.6's OCR-only score from 0/33 to
  **11/33, beating the 9/33 PaddleOCR baseline** (verified, not estimated).
- **Evaluates SmolVLM-256M/500M** on both strategies — 0/33 across the board, but for a
  qualitatively different reason than MiniCPM (schema invention / captioning-instead-of-OCR /
  repetition loops, not a formatting gap) — establishing a capability floor for this task.
- **Parametrizes the harness** with a `models.toml` manifest (single source of truth for every
  model this project is tracking, its HF repo/filenames, confirmed llama.cpp projector-type
  support, and status/notes) plus `scripts/fetch-model.sh` / `scripts/run-eval.sh` that key off
  it, and a `--limit N` flag on both benchmark binaries for cheap smoke tests.
- **Smoke-tests 9 new candidate models** (`--smoke`, 2 images each, no full evals run) — all load
  and run without crashing, confirming `llama-cpp-2` support for 8 additional vision-projector
  types. Three (LightOnOCR-1B, GLM-OCR, LFM2.5-VL-1.6B) show strong signal (passed a smoke image
  outright with clean transcription) and are the recommended next full runs.
- All findings are written up in `nutrition-fact-labeller/eval-results/` as dated reports plus a
  living summary (`eval-results/README.md`) meant to be appended to, not rewritten, going forward.

## Full eval results so far

| Model | Approach | Score | vs. baseline (9/33) |
|---|---|---|---|
| MiniCPM-V-4.6-Q4_K_M | Full JSON extraction | 0/33 | ▼ −9 |
| MiniCPM-V-4.6-Q4_K_M | OCR-only, resilient parser | **11/33** | **▲ +2** |
| SmolVLM-256M/500M-Instruct | Full JSON extraction | 0/33 (both) | ▼ −9 |
| SmolVLM-256M/500M-Instruct | OCR-only, resilient parser | 0/33 (both) | ▼ −9 |

9 more models are smoke-tested and ready for a full run — see
`eval-results/README.md`'s "Smoke-tested, not yet fully evaluated" table for the ranked list and
`models.toml` for per-model download info.

## Next steps (for whoever runs this on faster hardware)

```bash
cd nutrition-fact-labeller
./scripts/run-eval.sh lightonocr-1b   # or glm-ocr, lfm25-vl-1_6b, etc. — see models.toml
```

No full evals were run for the 9 new candidates in this PR by design — only smoke tests, to keep
this environment's CPU-only turnaround reasonable. Recommended order is in
`eval-results/README.md`.

## Test plan

- [x] `cargo build --release` (all binaries) — clean
- [x] `cargo test --release --lib` — 4/4 passing (includes 2 new regression fixtures for the
      resilient-parser fix, using real captured VLM transcriptions)
- [x] `cargo test --release --bin nutrition-fact-labeller` — 3/4 passing; the 4th
      (`check_test_cases`, the PaddleOCR baseline) fails in this sandbox only because the local
      ONNX model weight files it needs aren't present here — confirmed pre-existing/unrelated to
      this PR's changes (same failure on `main` before any of these commits)
- [x] Full 33-image `vlm_benchmark`/`vlm_ocr_benchmark` runs for MiniCPM-V 4.6 and SmolVLM (both
      sizes, both approaches) — see `eval-results/`
- [x] `--smoke` (2-image) runs for all 9 new candidate models — confirmed loading/running, no
      crashes
- [ ] Full 33-image runs for the 9 new candidates — intentionally left for faster hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MKDDAQ3d9uTpECoUaox4r

---
_Generated by [Claude Code](https://claude.ai/code/session_015MKDDAQ3d9uTpECoUaox4r)_