### PR TITLE
Prompt for a final answer on the last agent round in llm-nutrition-api

### DIFF
--- a/llm-nutrition-api/src/agent.rs
+++ b/llm-nutrition-api/src/agent.rs
@@ -312,8 +312,22 @@ async fn run_agent_local(
 
         log::debug!("[{request_id}] Model output: {output}");
 
+        let is_last_round = round + 1 == MAX_ROUNDS;
         let json_str = extract_json(&output).unwrap_or(&output);
-        if let Ok(call) = serde_json::from_str::<ToolCall>(json_str) {
+        let tool_call = serde_json::from_str::<ToolCall>(json_str).ok();
+
+        if is_last_round {
+            if let Some(call) = &tool_call {
+                if (call.action == "search_web" && !call.query.is_empty())
+                    || (call.action == "read_webpage" && !call.url.is_empty())
+                {
+                    log::warn!(
+                        "[{request_id}] Last round requested another tool call ({:?}); forcing a final answer instead",
+                        call.action
+                    );
+                }
+            }
+        } else if let Some(call) = tool_call {
             match call.action.as_str() {
                 "search_web" if !call.query.is_empty() => {
                     log::info!("[{request_id}] Tool call: search_web({:?})", call.query);
@@ -345,7 +359,7 @@ async fn run_agent_local(
             }
         }
 
-        // No tool call — do a focused final pass asking for pure JSON.
+        // No tool call (or last round) — do a focused final pass asking for pure JSON.
         // Grammar-constrained sampling (json_schema_to_grammar) crashes with this
         // version of llama.cpp; free-form output + extract_json is equally reliable.
         let backend_arc = Arc::clone(&backend);
@@ -392,8 +406,22 @@ async fn run_agent_api(
         let output = call_api(client, api_key, model, base_url, &conversation).await?;
         log::debug!("[{request_id}] Model output: {output}");
 
+        let is_last_round = round + 1 == MAX_ROUNDS;
         let json_str = extract_json(&output).unwrap_or(&output);
-        if let Ok(call) = serde_json::from_str::<ToolCall>(json_str) {
+        let tool_call = serde_json::from_str::<ToolCall>(json_str).ok();
+
+        if is_last_round {
+            if let Some(call) = &tool_call {
+                if (call.action == "search_web" && !call.query.is_empty())
+                    || (call.action == "read_webpage" && !call.url.is_empty())
+                {
+                    log::warn!(
+                        "[{request_id}] Last round requested another tool call ({:?}); forcing a final answer instead",
+                        call.action
+                    );
+                }
+            }
+        } else if let Some(call) = tool_call {
             match call.action.as_str() {
                 "search_web" if !call.query.is_empty() => {
                     log::info!("[{request_id}] Tool call: search_web({:?})", call.query);
@@ -425,7 +453,7 @@ async fn run_agent_api(
             }
         }
 
-        // No tool call — final pass requesting pure JSON.
+        // No tool call (or last round) — final pass requesting pure JSON.
         let mut final_conv = conversation.clone();
         final_conv.push(("assistant".to_string(), output));
         final_conv.push((

--- a/llm-nutrition-api/src/agent.rs
+++ b/llm-nutrition-api/src/agent.rs
@@ -301,6 +301,15 @@ async fn run_agent_local(
     for round in 0..MAX_ROUNDS {
         log::debug!("[{request_id}] Agent round {round}");
 
+        if round + 1 == MAX_ROUNDS {
+            conversation.push((
+                "user".to_string(),
+                "This is the final round: you must respond now with ONLY the complete JSON \
+                 nutrition object (all 14 fields), giving your best estimate from whatever \
+                 information you have so far. Do not call any more tools.".to_string(),
+            ));
+        }
+
         let backend_arc = Arc::clone(&backend);
         let model_arc = Arc::clone(&model);
         let conv_snapshot = conversation.clone();
@@ -312,22 +321,8 @@ async fn run_agent_local(
 
         log::debug!("[{request_id}] Model output: {output}");
 
-        let is_last_round = round + 1 == MAX_ROUNDS;
         let json_str = extract_json(&output).unwrap_or(&output);
-        let tool_call = serde_json::from_str::<ToolCall>(json_str).ok();
-
-        if is_last_round {
-            if let Some(call) = &tool_call {
-                if (call.action == "search_web" && !call.query.is_empty())
-                    || (call.action == "read_webpage" && !call.url.is_empty())
-                {
-                    log::warn!(
-                        "[{request_id}] Last round requested another tool call ({:?}); forcing a final answer instead",
-                        call.action
-                    );
-                }
-            }
-        } else if let Some(call) = tool_call {
+        if let Ok(call) = serde_json::from_str::<ToolCall>(json_str) {
             match call.action.as_str() {
                 "search_web" if !call.query.is_empty() => {
                     log::info!("[{request_id}] Tool call: search_web({:?})", call.query);
@@ -359,7 +354,7 @@ async fn run_agent_local(
             }
         }
 
-        // No tool call (or last round) — do a focused final pass asking for pure JSON.
+        // No tool call — do a focused final pass asking for pure JSON.
         // Grammar-constrained sampling (json_schema_to_grammar) crashes with this
         // version of llama.cpp; free-form output + extract_json is equally reliable.
         let backend_arc = Arc::clone(&backend);
@@ -403,25 +398,20 @@ async fn run_agent_api(
     for round in 0..MAX_ROUNDS {
         log::debug!("[{request_id}] Agent round {round}");
 
+        if round + 1 == MAX_ROUNDS {
+            conversation.push((
+                "user".to_string(),
+                "This is the final round: you must respond now with ONLY the complete JSON \
+                 nutrition object (all 14 fields), giving your best estimate from whatever \
+                 information you have so far. Do not call any more tools.".to_string(),
+            ));
+        }
+
         let output = call_api(client, api_key, model, base_url, &conversation).await?;
         log::debug!("[{request_id}] Model output: {output}");
 
-        let is_last_round = round + 1 == MAX_ROUNDS;
         let json_str = extract_json(&output).unwrap_or(&output);
-        let tool_call = serde_json::from_str::<ToolCall>(json_str).ok();
-
-        if is_last_round {
-            if let Some(call) = &tool_call {
-                if (call.action == "search_web" && !call.query.is_empty())
-                    || (call.action == "read_webpage" && !call.url.is_empty())
-                {
-                    log::warn!(
-                        "[{request_id}] Last round requested another tool call ({:?}); forcing a final answer instead",
-                        call.action
-                    );
-                }
-            }
-        } else if let Some(call) = tool_call {
+        if let Ok(call) = serde_json::from_str::<ToolCall>(json_str) {
             match call.action.as_str() {
                 "search_web" if !call.query.is_empty() => {
                     log::info!("[{request_id}] Tool call: search_web({:?})", call.query);
@@ -453,7 +443,7 @@ async fn run_agent_api(
             }
         }
 
-        // No tool call (or last round) — final pass requesting pure JSON.
+        // No tool call — final pass requesting pure JSON.
         let mut final_conv = conversation.clone();
         final_conv.push(("assistant".to_string(), output));
         final_conv.push((


### PR DESCRIPTION
## Summary
- With the new per-request logging live (#27) and `RUST_LOG` scoped down to our crate, we caught a live "max agent rounds exceeded" failure end-to-end: the model (`google/gemma-4-31b-it:free`) kept issuing new `search_web`/`read_webpage` calls every round — including on round 4, the last allowed round — instead of ever committing to a final JSON estimate, for a food item ("Chomps Chomplings mini beef stick") it apparently couldn't find clean nutrition facts for.
- Before the model call on the last round, inject a plain user message telling it this is the final round and it must answer now with the JSON nutrition object, no more tool calls. Lets the model reason its way to an answer instead of the code silently discarding whatever it says and forcing a rewrite after the fact (an earlier version of this PR did that; simplified based on review feedback). Applies to both the local (llama.cpp) and API (OpenRouter/Gemini) backends.

## Test plan
- [x] `cargo check` and `cargo test` pass
- [ ] Deploy and retry a previously-failing query (e.g. "Chomps Chomplings mini beef stick") to confirm it now returns an estimate instead of a 500
