### PR TITLE
Fix production SIGILL crash loop: pin Zig build to baseline CPU features

### DIFF
--- a/llm-nutrition-api/Containerfile
+++ b/llm-nutrition-api/Containerfile
@@ -25,7 +25,16 @@ WORKDIR /app
 COPY build.zig build.zig.zon ./
 COPY src ./src
 
-RUN zig build exe -Doptimize=ReleaseFast
+# -Dcpu=baseline is required: with no -Dtarget/-Dcpu given, Zig's default
+# "native" resolution bakes in whatever CPU feature extensions (AVX-512,
+# BMI2, etc.) the *build* machine happens to have, not just its arch/OS.
+# That's fine when build and run machines match, but this image is built on
+# GitHub Actions runners and run on DigitalOcean Kubernetes nodes with a
+# different CPU -- the mismatch caused a SIGILL crash loop in production
+# the first time a real request exercised a code path compiled to use an
+# instruction the DOKS node's CPU doesn't support. baseline targets the
+# generic x86_64 feature set, portable across any x86_64 Linux host.
+RUN zig build exe -Doptimize=ReleaseFast -Dcpu=baseline
 
 # =========================
 # 1. Runtime stage


### PR DESCRIPTION
## Summary
- `llm-nutrition-api` is currently crash-looping in production (`Exit Code: 132` = SIGILL) the moment a real `/lookup` request exercises enough code to hit an instruction the DigitalOcean Kubernetes node's CPU doesn't support.
- Root cause: the Containerfile's `zig build exe -Doptimize=ReleaseFast` passed no `-Dtarget`/`-Dcpu`, so Zig's default "native" resolution baked in whatever CPU feature extensions the *build* machine (a GitHub Actions runner) has. That's fine when build and run machines match, but broken here since the image is built on GHA and run on a different DOKS node CPU.
- Fix: add `-Dcpu=baseline`, which targets the generic/portable x86_64 feature set instead of the build host's exact CPU.

## Test plan
- [x] `zig build exe -Doptimize=ReleaseFast -Dcpu=baseline` succeeds locally
- [x] Resulting binary has identical characteristics to before (`file`/`ldd`: static, stripped, "not a dynamic executable")
- [x] `zig build test` — 62/62 tests pass
- [ ] CI green on this PR
- [ ] New image verified not to crash under a real `/lookup` request once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159eSWojaDUkeiRf2jMWsEn

---
_Generated by [Claude Code](https://claude.ai/code/session_0159eSWojaDUkeiRf2jMWsEn)_