### PR TITLE
Fix /upload: dupe the multipart boundary before reading the body

### DIFF
--- a/llm-nutrition-api/src/main.zig
+++ b/llm-nutrition-api/src/main.zig
@@ -190,10 +190,16 @@ fn handleUpload(ctx: ConnCtx, env: root.Env, request: *std.http.Server.Request) 
         std.log.warn("[{d}] Upload rejected: missing content-type", .{request_id});
         return respondError(request, .bad_request, "missing content-type");
     };
-    const boundary = extractBoundary(content_type) orelse {
+    const boundary_view = extractBoundary(content_type) orelse {
         std.log.warn("[{d}] Upload rejected: missing multipart boundary (content-type: {s})", .{ request_id, content_type });
         return respondError(request, .bad_request, "missing multipart boundary");
     };
+    // `content_type` (and thus `boundary_view`) is a slice into the
+    // connection's small header-parsing buffer, not caller-owned memory --
+    // reading the (potentially much larger) body below reuses that same
+    // buffer, silently corrupting any slice still pointing into it. Copy
+    // the boundary out before that happens.
+    const boundary = try env.allocator.dupe(u8, boundary_view);
 
     var body_read_buf: [8 * 1024]u8 = undefined;
     const body_reader = try request.readerExpectContinue(&body_read_buf);


### PR DESCRIPTION
## Summary
- Root cause of the reported "image scan" failures, found via v1.0.3's new diagnostics (#32): every failing request had a perfectly well-formed multipart body (`Content-Disposition: form-data; name="image"; filename="capture.jpg"` present and correct), but the *boundary value* logged as corrupted garbage bytes instead of the real string.
- `content_type` (and the `boundary` slice extracted from it) is a view into the connection's small header-parsing buffer, not caller-owned memory. Reading the body afterward (347KB in the reported case, far bigger than that buffer) reuses and overwrites it, corrupting `boundary` before `extractImagePart` ever uses it to search the body. The body was fine the whole time — the search key wasn't.
- Fix: copy the boundary into `env.allocator`-owned memory right after extraction, before the body read can invalidate it.

## Test plan
- [x] `zig build test` — 62/62 pass
- [x] `zig build` succeeds
- [ ] CI green
- [ ] Real upload succeeds once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159eSWojaDUkeiRf2jMWsEn

---
_Generated by [Claude Code](https://claude.ai/code/session_0159eSWojaDUkeiRf2jMWsEn)_