### PR TITLE
Redirect to login when the cached Auth0 token is missing or invalid

### DIFF
--- a/web/src/Auth0.test.ts
+++ b/web/src/Auth0.test.ts
@@ -23,10 +23,11 @@ describe("Auth0", () => {
     });
   });
 
-  it("should configure auth0 client and check authentication status when not authenticated", async () => {
+  it("should configure auth0 client and redirect to login when not authenticated", async () => {
     const mockClient = {
       isAuthenticated: vi.fn().mockResolvedValue(false),
       handleRedirectCallback: vi.fn(),
+      loginWithRedirect: vi.fn().mockResolvedValue(undefined),
     };
     vi.mocked(createAuth0Client).mockResolvedValue(mockClient as any);
 
@@ -41,6 +42,7 @@ describe("Auth0", () => {
       redirect_uri: "http://localhost:3000/auth/callback",
       cacheLocation: "localstorage",
     });
+    expect(mockClient.loginWithRedirect).toHaveBeenCalled();
     expect(authState.isAuthenticated()).toBe(false);
   });
 
@@ -57,6 +59,7 @@ describe("Auth0", () => {
     const mockClient = {
       handleRedirectCallback: vi.fn().mockResolvedValue({}),
       isAuthenticated: vi.fn().mockResolvedValue(false),
+      loginWithRedirect: vi.fn().mockResolvedValue(undefined),
     };
     vi.mocked(createAuth0Client).mockResolvedValue(mockClient as any);
 
@@ -89,5 +92,24 @@ describe("Auth0", () => {
     expect(authState.isAuthenticated()).toBe(true);
     expect(authState.user()).toEqual(mockUser);
     expect(authState.accessToken()).toBe(mockToken);
+  });
+
+  it("should redirect to login when the session looks active but the cached token is gone", async () => {
+    const mockClient = {
+      isAuthenticated: vi.fn().mockResolvedValue(true),
+      getUser: vi.fn().mockResolvedValue({ name: "Test User" }),
+      getTokenSilently: vi.fn().mockRejectedValue(new Error("login_required")),
+      handleRedirectCallback: vi.fn(),
+      loginWithRedirect: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(createAuth0Client).mockResolvedValue(mockClient as any);
+
+    const [authState] = useAuth();
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(mockClient.loginWithRedirect).toHaveBeenCalled();
+    expect(authState.isAuthenticated()).toBe(false);
+    expect(authState.accessToken()).toBe("");
   });
 });

--- a/web/src/Auth0.ts
+++ b/web/src/Auth0.ts
@@ -24,10 +24,32 @@ export function useAuth() {
       await client.handleRedirectCallback(location.href);
       navigate("/", { replace: true });
     }
-    if (setIsAuthenticated(await client.isAuthenticated())) {
-      setUser(await client.getUser());
-      setAccessToken(await client.getTokenSilently());
+
+    if (!(await client.isAuthenticated())) {
+      await client.loginWithRedirect();
+      return client;
     }
+
+    // isAuthenticated() only reflects the SDK's local session state, not
+    // whether the cached token is still usable (e.g. the refresh token
+    // expired, or third-party cookies got blocked mid-session) -- confirm
+    // getTokenSilently() actually returns one before treating the user as
+    // logged in, otherwise the app renders as authenticated while every
+    // API call fails.
+    let token: string;
+    try {
+      token = await client.getTokenSilently();
+    } catch {
+      token = "";
+    }
+    if (!token) {
+      await client.loginWithRedirect();
+      return client;
+    }
+
+    setIsAuthenticated(true);
+    setUser(await client.getUser());
+    setAccessToken(token);
     return client;
   });
 


### PR DESCRIPTION
isAuthenticated() only reflected the SDK's local session state, not
whether getTokenSilently() could actually produce a usable token. A
stale/expired session let the app render as logged in while every
authenticated request (including image upload for label scanning)
failed with no useful feedback. Now a missing/failed token redirects
straight to Auth0 login instead of leaving the user in that broken
state.