### PR TITLE
Stamp RFC 9207 iss on OAuth callback redirects

### DIFF
--- a/mcp-server/src/index.test.ts
+++ b/mcp-server/src/index.test.ts
@@ -10,6 +10,8 @@ import { issueAccessToken, issueRefreshToken, validateRefreshToken } from "./tok
 const SECRET = "test-secret-key";
 const AUDIENCE = "https://direct-satyr-14.hasura.app/v1/graphql";
 const AUTH0_DOMAIN = "motingo.auth0.com";
+// Matches index.ts's default (MCP_SERVER_URL is not set in these tests).
+const BASE_URL = "http://localhost:3032";
 
 function makeToken() {
   return sign({ sub: "user-123" }, SECRET, { audience: AUDIENCE, expiresIn: "1h" });
@@ -106,6 +108,11 @@ describe("GET /.well-known/oauth-authorization-server", () => {
     expect(res.body.grant_types_supported).toContain("authorization_code");
     expect(res.body.grant_types_supported).toContain("refresh_token");
   });
+
+  it("advertises RFC 9207 iss parameter support", async () => {
+    const res = await supertest(app).get("/.well-known/oauth-authorization-server");
+    expect(res.body.authorization_response_iss_parameter_supported).toBe(true);
+  });
 });
 
 // ─── GET /mcp/authorize ───────────────────────────────────────────────────────
@@ -189,6 +196,8 @@ describe("GET /mcp/callback", () => {
     expect(redirectUrl.hostname).toBe("claude.ai");
     expect(redirectUrl.searchParams.get("state")).toBe("claude-state");
     expect(redirectUrl.searchParams.get("code")).toBeTruthy();
+    // RFC 9207: lets the client detect mix-up attacks.
+    expect(redirectUrl.searchParams.get("iss")).toBe(BASE_URL);
   });
 
   it("forwards Auth0 errors to Claude's callback", async () => {
@@ -207,6 +216,7 @@ describe("GET /mcp/callback", () => {
     const redirectUrl = new URL(res.headers.location as string);
     expect(redirectUrl.searchParams.get("error")).toBe("access_denied");
     expect(redirectUrl.searchParams.get("state")).toBe("claude-state");
+    expect(redirectUrl.searchParams.get("iss")).toBe(BASE_URL);
   });
 
   it("uses error code as description when error_description is absent", async () => {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -58,6 +58,9 @@ app.get("/.well-known/oauth-authorization-server", (_req, res) => {
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
+    // RFC 9207: we stamp `iss` on every redirect back to the client, so
+    // clients can skip issuer discovery and validate it directly.
+    authorization_response_iss_parameter_supported: true,
   });
 });
 
@@ -110,7 +113,7 @@ app.get(new URL(CALLBACK_ENDPOINT).pathname, async (req, res) => {
 
   if (error) {
     logger.warn("callback: auth0 error", { error, error_description });
-    const p = new URLSearchParams({ error, error_description: error_description ?? error });
+    const p = new URLSearchParams({ error, error_description: error_description ?? error, iss: BASE_URL });
     if (pending.clientState) p.set("state", pending.clientState);
     res.redirect(`${pending.clientRedirectUri}?${p.toString()}`);
     return;
@@ -150,7 +153,7 @@ app.get(new URL(CALLBACK_ENDPOINT).pathname, async (req, res) => {
     if (!sub) throw new Error("Could not extract sub from id_token");
   } catch (e) {
     logger.error("callback: token exchange failed", { error: (e as Error).message });
-    const p = new URLSearchParams({ error: "server_error" });
+    const p = new URLSearchParams({ error: "server_error", iss: BASE_URL });
     if (pending.clientState) p.set("state", pending.clientState);
     res.redirect(`${pending.clientRedirectUri}?${p.toString()}`);
     return;
@@ -163,7 +166,9 @@ app.get(new URL(CALLBACK_ENDPOINT).pathname, async (req, res) => {
 
   logger.info("callback: issued code", { sub, hasRefreshToken: Boolean(refreshToken) });
 
-  const p = new URLSearchParams({ code: ourCode });
+  // RFC 9207: stamp our issuer identifier on the redirect so the client can
+  // detect mix-up attacks (a malicious AS relaying its own code/state pair).
+  const p = new URLSearchParams({ code: ourCode, iss: BASE_URL });
   if (pending.clientState) p.set("state", pending.clientState);
   res.redirect(`${pending.clientRedirectUri}?${p.toString()}`);
 });


### PR DESCRIPTION
The 2026-07-28 MCP spec revision hardens client-side issuer validation
(SEP-2207) as a mix-up-attack defense: clients check the `iss` query
param on the authorization redirect against the AS's advertised
issuer. Our hand-rolled OAuth AS (Claude.ai <-> us <-> Auth0) wasn't
setting it on any of the three redirects back to Claude.ai, and our
metadata endpoint didn't advertise support.